### PR TITLE
fix: handle missing temperature sensor

### DIFF
--- a/vserver-ssh-stats/app/collector.py
+++ b/vserver-ssh-stats/app/collector.py
@@ -102,8 +102,9 @@ fi
 rx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print rx+0}' /proc/net/dev)
 tx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print tx+0}' /proc/net/dev)
 
+if [ -n "$temp" ]; then temp_json=$temp; else temp_json=null; fi
 printf '{"cpu":%s,"mem":%s,"disk":%s,"uptime":%s,"temp":%s,"rx":%s,"tx":%s}\n' \
-  "$cpu" "$mem" "$disk" "$uptime" "${temp:-null}" "$rx" "$tx"
+  "$cpu" "$mem" "$disk" "$uptime" "$temp_json" "$rx" "$tx"
 '''
 
 def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:

--- a/vserver-ssh-stats/config.yaml
+++ b/vserver-ssh-stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.0"
+version: "0.1.1"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- ensure remote stats script outputs proper JSON when temperature sensor is absent
- bump add-on version to 0.1.1

## Testing
- `python3 -m py_compile vserver-ssh-stats/app/collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae88506bcc8327b1dd6ba0c4c308ce