### PR TITLE
Fix libcrypt build error for VServer SSH Stats add-on

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.2.2
 FROM ${BUILD_FROM}
 
-RUN apk add --no-cache python3 py3-pip jq \
+RUN apk add --no-cache python3 py3-pip jq libxcrypt-dev \
  && pip3 install --no-cache-dir paramiko paho-mqtt
 
 COPY run.sh /run.sh

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.1"
+version: "0.1.2"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- add libxcrypt-dev to Docker image so paramiko installs cleanly
- bump add-on version to 0.1.2

## Testing
- ❌ `docker build -t vserver-ssh-stats-test vserver_ssh_stats >/tmp/build.log && tail -n 20 /tmp/build.log` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68af17531a1c8327a6a83d5cf54a4886