### PR TITLE
fix: update docker deps

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -1,8 +1,8 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.2.2
 FROM ${BUILD_FROM}
 
-RUN apk add --no-cache python3 py3-pip jq libxcrypt-dev \
- && pip3 install --no-cache-dir paramiko paho-mqtt
+RUN apk add --no-cache python3 py3-pip py3-setuptools python3-dev build-base \
+    && pip3 install --no-cache-dir wheel paramiko paho-mqtt
 
 COPY run.sh /run.sh
 COPY app /app


### PR DESCRIPTION
## Summary
- install correct python build dependencies and wheel

## Testing
- `docker build -t vserver-ssh-stats-test vserver_ssh_stats` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a065c848327baed654ea3b17ee1