### PR TITLE
fix: allow pip installs in Dockerfile

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.2.2
 FROM ${BUILD_FROM}
 
 RUN apk add --no-cache python3 py3-pip py3-setuptools python3-dev build-base \
-    && pip3 install --no-cache-dir wheel paramiko paho-mqtt
+    && pip3 install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
 
 COPY run.sh /run.sh
 COPY app /app


### PR DESCRIPTION
## Summary
- add `--break-system-packages` flag to pip install to allow installing required dependencies

## Testing
- `python3 -m py_compile vserver_ssh_stats/app/collector.py`
- `docker build -t vserver-ssh-stats-test ./vserver_ssh_stats` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68af1bb563208327ba23bceb3e884ba1