### PR TITLE
fix: ensure s6 init entrypoint

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -7,4 +7,5 @@ RUN apk add --no-cache python3 py3-pip py3-setuptools python3-dev build-base \
 COPY run.sh /run.sh
 COPY app /app
 RUN chmod a+x /run.sh
+ENTRYPOINT ["/init"]
 CMD ["/run.sh"]

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.3"
+version: "0.1.4"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- ensure add-on runs under s6 by setting `/init` as the container entrypoint
- bump add-on version to 0.1.4

## Testing
- `bash -n vserver_ssh_stats/run.sh`
- `python3 -m py_compile vserver_ssh_stats/app/collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68af24b632448327a037eb03ff19f7f7