### PR TITLE
fix: enable s6 init

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -7,4 +7,5 @@ RUN apk add --no-cache python3 py3-pip py3-setuptools python3-dev build-base \
 COPY run.sh /run.sh
 COPY app /app
 RUN chmod a+x /run.sh
+ENTRYPOINT ["/init"]
 CMD ["/run.sh"]

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,10 +1,11 @@
 name: VServer SSH Stats
-version: "0.1.3"
+version: "0.1.5"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services
 boot: auto
 ingress: false
+init: false
 arch:
   - amd64
   - armv7


### PR DESCRIPTION
## Summary
- ensure Home Assistant Supervisor starts with s6 by setting `init: false`
- bump add-on version to 0.1.5

## Testing
- `bash -n vserver_ssh_stats/run.sh`
- `python3 -m py_compile vserver_ssh_stats/app/collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68af24b632448327a037eb03ff19f7f7