### PR TITLE
Allow running without MQTT broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If you want to gather stats without using MQTT, run `app/simple_collector.py`. T
 
 Optionally you can enter your Home Assistant base URL and a long-lived access token. When provided, the script will create sensors like `sensor.<name>_cpu`, `sensor.<name>_mem`, etc., via the Home Assistant REST API for each server so the values show up in the UI without MQTT.
 
+The main collector (`app/collector.py`) also supports a lightweight mode without MQTT: simply run it without the `MQTT_HOST` environment variable. In that case the collected statistics are logged to the console instead of being published to a broker.
+
 
 ---
 


### PR DESCRIPTION
## Summary
- make MQTT optional in `collector.py` with graceful fallback to logging
- update docs describing non-MQTT mode

## Testing
- `pytest -q`
- `python -m py_compile vserver_ssh_stats/app/collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b455328e2c83278cf3c6827869d2e3