### PR TITLE
Add HACS integration scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,29 @@ The main collector (`app/collector.py`) also supports a lightweight mode without
 ---
 
 ## Installation
-1. Copy the add-on folder `vserver_ssh_stats` into your local Home Assistant add-on repository  
-   (e.g. `/addons/vserver_ssh_stats`).  
 
-2. In Home Assistant:  
-   - Navigate to **Settings → Add-ons → Add-on Store**.  
-   - Click the three-dot menu → **Repositories**.  
-   - Add your local add-on repository path or Git repository containing this add-on.  
+### Via HACS (Home Assistant Community Store)
+1. Ensure [HACS](https://hacs.xyz) is installed in Home Assistant.
+2. In HACS, add `https://github.com/404GamerNotFound/vserver-ssh-stats` as a custom repository (type: integration).
+3. Search for **VServer SSH Stats** and install the integration.
+4. Restart Home Assistant to load the new integration.
 
-3. The add-on **VServer SSH Stats** should now appear in the list. Click **Install**.  
+### Manual Add-on Installation
+1. Copy the add-on folder `vserver_ssh_stats` into your local Home Assistant add-on repository
+   (e.g. `/addons/vserver_ssh_stats`).
 
-4. Configure the add-on (see below).  
+2. In Home Assistant:
+   - Navigate to **Settings → Add-ons → Add-on Store**.
+   - Click the three-dot menu → **Repositories**.
+   - Add your local add-on repository path or Git repository containing this add-on.
 
-5. Start the add-on.  
+3. The add-on **VServer SSH Stats** should now appear in the list. Click **Install**.
 
-6. After a short while, new entities (sensors) will automatically appear in Home Assistant via MQTT Discovery.  
+4. Configure the add-on (see below).
+
+5. Start the add-on.
+
+6. After a short while, new entities (sensors) will automatically appear in Home Assistant via MQTT Discovery.
 
 ---
 

--- a/custom_components/vserver_ssh_stats/__init__.py
+++ b/custom_components/vserver_ssh_stats/__init__.py
@@ -1,0 +1,29 @@
+"""VServer SSH Stats integration for Home Assistant."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "vserver_ssh_stats"
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the VServer SSH Stats integration."""
+    _LOGGER.debug("Setting up VServer SSH Stats")
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up VServer SSH Stats from a config entry."""
+    _LOGGER.debug("Setting up VServer SSH Stats entry")
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a VServer SSH Stats config entry."""
+    _LOGGER.debug("Unloading VServer SSH Stats entry")
+    return True

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "vserver_ssh_stats",
+  "name": "VServer SSH Stats",
+  "version": "0.1.9",
+  "documentation": "https://github.com/404GamerNotFound/vserver-ssh-stats",
+  "requirements": [],
+  "codeowners": [
+    "@404GamerNotFound"
+  ],
+  "integration_type": "service"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "VServer SSH Stats",
+  "content_in_root": false,
+  "render_readme": true,
+  "domains": ["vserver_ssh_stats"]
+}

--- a/repository.json
+++ b/repository.json
@@ -1,6 +1,5 @@
 {
-    "name": "VServer SSH Stats Repository",
-    "url": "https://github.com/404GamerNotFound/vserver-ssh-stats",
-    "maintainer": "Tony Brüser <tony@brueser.eu"
-  }
-  
+  "name": "VServer SSH Stats Repository",
+  "url": "https://github.com/404GamerNotFound/vserver-ssh-stats",
+  "maintainer": "Tony Brüser <tony@brueser.eu>"
+}


### PR DESCRIPTION
## Summary
- add basic custom component scaffolding for VServer SSH Stats
- include hacs.json and documentation for HACS installation
- align manifest metadata with repository details and project version

## Testing
- `python -m py_compile custom_components/vserver_ssh_stats/__init__.py`
- `python -m json.tool custom_components/vserver_ssh_stats/manifest.json`
- `python -m json.tool hacs.json`
- `python -m json.tool repository.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4608a38a48327abe4de9184e65c65