### PR TITLE
Add HACS compliance files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@main
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @404GamerNotFound

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tony Brüser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -3,6 +3,7 @@
   "name": "VServer SSH Stats",
   "version": "0.1.9",
   "documentation": "https://github.com/404GamerNotFound/vserver-ssh-stats",
+  "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
   "codeowners": [
     "@404GamerNotFound"

--- a/custom_components/vserver_ssh_stats/translations/en.json
+++ b/custom_components/vserver_ssh_stats/translations/en.json
@@ -1,0 +1,3 @@
+{
+  "title": "VServer SSH Stats"
+}

--- a/info.md
+++ b/info.md
@@ -1,0 +1,5 @@
+# VServer SSH Stats
+
+Monitor remote Linux servers over SSH and publish metrics to Home Assistant via MQTT.
+
+For full installation and configuration instructions, see the [README](README.md).


### PR DESCRIPTION
## Summary
- Add HACS and Hassfest validation workflow
- Provide metadata files for HACS publication
- Link issue tracker in manifest

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b46419bf8c83278649431e1b5bb47e