### PR TITLE
Fix Hassfest action branch reference

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@main
+        uses: home-assistant/actions/hassfest@master
       - name: HACS validation
         uses: hacs/action@main
         with:


### PR DESCRIPTION
## Summary
- use master branch for Hassfest GitHub Action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b465bec3508327af8b8a6e6d4b8a20