### PR TITLE
Add multilingual documentation and translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,158 @@
+# VServer SSH Stats – Home Assistant Add-on
+
+## Übersicht
+Das **VServer SSH Stats** Add-on für Home Assistant ermöglicht die Überwachung entfernter Linux-Server (vServer, Raspberry Pi oder dedizierte Maschinen), ohne zusätzliche Agenten auf den Zielrechnern zu installieren.
+
+Das Add-on verbindet sich per **SSH** (über IP-Adresse, Benutzername und Passwort oder SSH-Schlüssel) und sammelt Systemmetriken direkt aus `/proc`, `df` und anderen Standard-Linux-Schnittstellen.
+Die Metriken werden anschließend über **MQTT Discovery** an Home Assistant veröffentlicht, sodass sie als native Sensoren erscheinen.
+
+Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurchsatz- und Temperaturinformationen in Echtzeit von all Ihren Servern in Home Assistant Dashboards anzuzeigen.
+
+---
+
+## Funktionen
+- Keine Softwareinstallation auf dem Zielserver erforderlich (nur SSH-Zugriff).
+- Unterstützt mehrere Server mit individueller Konfiguration.
+- Unterstützt Passwort- und SSH-Schlüssel-Authentifizierung.
+- Sammelt:
+  - CPU-Auslastung (%)
+  - Speicherauslastung (%)
+  - Festplattenauslastung (% für `/`)
+  - Netzwerkdurchsatz (Bytes/s, ein- und ausgehend)
+  - Laufzeit (Sekunden)
+  - Temperatur (°C, falls verfügbar)
+- Automatische **MQTT Discovery** für einfache Integration in Home Assistant.
+- Konfigurierbares Aktualisierungsintervall (Standard: 30 Sekunden).
+
+### Standalone-Nutzung ohne MQTT
+
+Wenn du Statistiken ohne MQTT sammeln möchtest, führe `app/simple_collector.py` aus. Das Skript ermöglicht dir die Eingabe eines oder mehrerer Server (drücke Enter bei der Host-Eingabe, um abzuschließen). Für jeden Server fragt es Host, Benutzername und entweder ein Passwort oder den Pfad zu einem SSH-Schlüssel sowie optional den Port ab und gibt dann alle 30 Sekunden eine JSON-Zeile mit dem Servernamen und CPU-, Speicher-, Festplatten-, Netzwerk-, Laufzeit- und Temperaturwerten aus.
+
+Optional kannst du deine Home Assistant Basis-URL und ein Long-Lived Access Token angeben. Wenn vorhanden, erstellt das Skript über die Home Assistant REST API Sensoren wie `sensor.<name>_cpu`, `sensor.<name>_mem` usw., damit die Werte ohne MQTT in der Oberfläche erscheinen.
+
+Der Haupt-Collector (`app/collector.py`) unterstützt ebenfalls einen leichtgewichtigen Modus ohne MQTT: Führe ihn einfach ohne die Umgebungsvariable `MQTT_HOST` aus. In diesem Fall werden die gesammelten Statistiken in der Konsole protokolliert, anstatt an einen Broker gesendet zu werden.
+
+---
+
+## Installation
+
+### Über HACS (Home Assistant Community Store)
+1. Stelle sicher, dass [HACS](https://hacs.xyz) in Home Assistant installiert ist.
+2. Füge in HACS `https://github.com/404GamerNotFound/vserver-ssh-stats` als benutzerdefiniertes Repository (Typ: Integration) hinzu.
+3. Suche nach **VServer SSH Stats** und installiere die Integration.
+4. Starte Home Assistant neu, um die neue Integration zu laden.
+
+### Manuelle Add-on-Installation
+1. Kopiere den Add-on-Ordner `vserver_ssh_stats` in dein lokales Home Assistant Add-on-Repository (z. B. `/addons/vserver_ssh_stats`).
+
+2. In Home Assistant:
+   - Navigiere zu **Einstellungen → Add-ons → Add-on Store**.
+   - Klicke auf das Drei-Punkte-Menü → **Repositories**.
+   - Füge deinen lokalen Add-on-Repository-Pfad oder das Git-Repository hinzu, das dieses Add-on enthält.
+
+3. Das Add-on **VServer SSH Stats** sollte nun in der Liste erscheinen. Klicke auf **Installieren**.
+
+4. Konfiguriere das Add-on (siehe unten).
+
+5. Starte das Add-on.
+
+6. Nach kurzer Zeit erscheinen neue Entitäten (Sensoren) automatisch in Home Assistant über MQTT Discovery.
+
+---
+
+## Konfiguration
+
+Die Konfiguration wird in `options.json` gespeichert (bearbeitbar über die Add-on-Oberfläche).
+
+Beispiel:
+
+```yaml
+mqtt_host: homeassistant
+mqtt_port: 1883
+mqtt_user: mqttuser
+mqtt_pass: mqttpassword
+interval_seconds: 30
+servers:
+  - name: "pi5"
+    host: "192.168.1.10"
+    username: "tony"
+    password: "supersecret"
+  - name: "vps1"
+    host: "203.0.113.42"
+    username: "root"
+    key: "/config/ssh/id_rsa"
+    port: 22
+```
+
+### Optionen
+- **mqtt_host** – Hostname/IP deines MQTT-Brokers (normalerweise `homeassistant`).
+- **mqtt_port** – Port des MQTT-Brokers (Standard: `1883`).
+- **mqtt_user / mqtt_pass** – MQTT-Anmeldedaten.
+- **interval_seconds** – Abfrageintervall in Sekunden (mindestens 5).
+- **servers** – Liste der zu überwachenden Server:
+  - `name` – Anzeigename (wird als Präfix für Entitäten verwendet).
+  - `host` – IP-Adresse oder Hostname des Servers.
+  - `username` – SSH-Benutzername.
+  - `password` – SSH-Passwort (optional, wenn `key` verwendet wird).
+  - `key` – Pfad zu einer SSH-Schlüsseldatei (optional).
+  - `port` – (Optional) SSH-Port (Standard `22`).
+
+---
+
+## Erstellte Entitäten
+
+Für jeden Server sind folgende Entitäten verfügbar:
+
+- `sensor.<name>_cpu` – CPU-Auslastung (%)
+- `sensor.<name>_mem` – Speicherauslastung (%)
+- `sensor.<name>_disk` – Festplattenauslastung (%)
+- `sensor.<name>_net_in` – Netzwerkeingang (Bytes/s)
+- `sensor.<name>_net_out` – Netzwerkausgang (Bytes/s)
+- `sensor.<name>_uptime` – Laufzeit (Sekunden)
+- `sensor.<name>_temp` – Temperatur (°C, falls verfügbar)
+
+---
+
+## Beispiel für ein Lovelace-Dashboard
+
+```yaml
+type: vertical-stack
+cards:
+  - type: gauge
+    name: VPS1 CPU
+    entity: sensor.vps1_cpu
+  - type: gauge
+    name: VPS1 Memory
+    entity: sensor.vps1_mem
+  - type: entities
+    title: VPS1 Details
+    entities:
+      - sensor.vps1_disk
+      - sensor.vps1_net_in
+      - sensor.vps1_net_out
+      - sensor.vps1_uptime
+      - sensor.vps1_temp
+```
+
+## Sicherheitshinweise
+- Es wird empfohlen, einen dedizierten, eingeschränkten Benutzer für das SSH-Monitoring zu erstellen (mit nur Lesezugriff auf `/proc` und `df`).
+- SSH-Passwortauthentifizierung wird unterstützt, aber **SSH-Schlüssel-Authentifizierung** wird für den produktiven Einsatz dringend empfohlen.
+- Der Netzwerkverkehr zwischen Home Assistant und deinen Servern ist unverschlüsselt, sofern du kein TLS für MQTT aktivierst.
+
+---
+
+## Anforderungen
+- Home Assistant mit MQTT-Broker (eingebauter Mosquitto oder extern).
+- SSH-Zugang zu den überwachten Servern.
+- Linux-basierte Zielserver (beliebige Distribution mit `/proc` und `df`).
+
+---
+
+## Lizenz
+Dieses Projekt ist unter der **MIT-Lizenz** lizenziert.
+
+---
+
+## Autor
+**Tony Brüser**
+Originalautor und Maintainer dieses Add-ons.

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,158 @@
+# VServer SSH Stats – Complemento de Home Assistant
+
+## Descripción general
+El complemento **VServer SSH Stats** para Home Assistant te permite supervisar servidores Linux remotos (vServers, Raspberry Pi o máquinas dedicadas) sin instalar agentes adicionales en las máquinas objetivo.
+
+El complemento se conecta mediante **SSH** (usando dirección IP, nombre de usuario y contraseña o clave SSH) y recopila métricas del sistema directamente de `/proc`, `df` y otras interfaces estándar de Linux.
+Las métricas se publican en Home Assistant mediante **MQTT Discovery**, por lo que aparecen como sensores nativos.
+
+Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiempo de actividad, rendimiento de red y temperatura de todos tus servidores en los paneles de Home Assistant.
+
+---
+
+## Características
+- No se requiere instalación de software en el servidor de destino (solo acceso SSH).
+- Soporta múltiples servidores con configuración individual.
+- Soporta autenticación por contraseña y por clave SSH.
+- Recopila:
+  - Uso de CPU (%)
+  - Uso de memoria (%)
+  - Uso de disco (% para `/`)
+  - Rendimiento de red (bytes/s de entrada y salida)
+  - Tiempo de actividad (segundos)
+  - Temperatura (°C, si está disponible)
+- **MQTT Discovery** automática para una fácil integración con Home Assistant.
+- Intervalo de actualización configurable (por defecto: 30 segundos).
+
+### Uso independiente sin MQTT
+
+Si deseas recopilar estadísticas sin MQTT, ejecuta `app/simple_collector.py`. El script permite introducir uno o varios servidores (pulsa Enter en el campo de host para finalizar). Para cada servidor solicita host, nombre de usuario y una contraseña o la ruta a una clave SSH más un puerto opcional, y luego imprime cada 30 segundos una línea JSON con el nombre del servidor y los valores de CPU, memoria, disco, red, tiempo de actividad y temperatura.
+
+Opcionalmente puedes introducir la URL base de Home Assistant y un token de acceso de larga duración. Si se proporcionan, el script creará sensores como `sensor.<name>_cpu`, `sensor.<name>_mem`, etc. mediante la API REST de Home Assistant para que los valores aparezcan en la interfaz sin MQTT.
+
+El colector principal (`app/collector.py`) también admite un modo ligero sin MQTT: simplemente ejecútalo sin la variable de entorno `MQTT_HOST`. En ese caso, las estadísticas recopiladas se registran en la consola en lugar de publicarse en un broker.
+
+---
+
+## Instalación
+
+### A través de HACS (Home Assistant Community Store)
+1. Asegúrate de que [HACS](https://hacs.xyz) esté instalado en Home Assistant.
+2. En HACS, añade `https://github.com/404GamerNotFound/vserver-ssh-stats` como repositorio personalizado (tipo: integración).
+3. Busca **VServer SSH Stats** e instala la integración.
+4. Reinicia Home Assistant para cargar la nueva integración.
+
+### Instalación manual del complemento
+1. Copia la carpeta del complemento `vserver_ssh_stats` en tu repositorio local de complementos de Home Assistant (por ejemplo, `/addons/vserver_ssh_stats`).
+
+2. En Home Assistant:
+   - Ve a **Ajustes → Add-ons → Add-on Store**.
+   - Haz clic en el menú de tres puntos → **Repositories**.
+   - Añade la ruta a tu repositorio local de complementos o el repositorio Git que contiene este complemento.
+
+3. El complemento **VServer SSH Stats** debería aparecer ahora en la lista. Haz clic en **Install**.
+
+4. Configura el complemento (ver abajo).
+
+5. Inicia el complemento.
+
+6. Tras un breve período, nuevas entidades (sensores) aparecerán automáticamente en Home Assistant mediante MQTT Discovery.
+
+---
+
+## Configuración
+
+La configuración se almacena en `options.json` (editable mediante la interfaz del complemento).
+
+Ejemplo:
+
+```yaml
+mqtt_host: homeassistant
+mqtt_port: 1883
+mqtt_user: mqttuser
+mqtt_pass: mqttpassword
+interval_seconds: 30
+servers:
+  - name: "pi5"
+    host: "192.168.1.10"
+    username: "tony"
+    password: "supersecret"
+  - name: "vps1"
+    host: "203.0.113.42"
+    username: "root"
+    key: "/config/ssh/id_rsa"
+    port: 22
+```
+
+### Opciones
+- **mqtt_host** – Nombre de host/IP de tu broker MQTT (normalmente `homeassistant`).
+- **mqtt_port** – Puerto del broker MQTT (predeterminado: `1883`).
+- **mqtt_user / mqtt_pass** – Credenciales MQTT.
+- **interval_seconds** – Intervalo de sondeo en segundos (mínimo 5).
+- **servers** – Lista de servidores a supervisar:
+  - `name` – Nombre amigable (usado como prefijo de entidad).
+  - `host` – Dirección IP o nombre de host del servidor.
+  - `username` – Nombre de usuario SSH.
+  - `password` – Contraseña SSH (opcional si se usa `key`).
+  - `key` – Ruta a un archivo de clave privada SSH (opcional).
+  - `port` – (Opcional) Puerto SSH (por defecto `22`).
+
+---
+
+## Entidades creadas
+
+Para cada servidor estarán disponibles las siguientes entidades:
+
+- `sensor.<name>_cpu` – Uso de CPU (%)
+- `sensor.<name>_mem` – Uso de memoria (%)
+- `sensor.<name>_disk` – Uso de disco (%)
+- `sensor.<name>_net_in` – Tráfico de entrada (bytes/s)
+- `sensor.<name>_net_out` – Tráfico de salida (bytes/s)
+- `sensor.<name>_uptime` – Tiempo de actividad (segundos)
+- `sensor.<name>_temp` – Temperatura (°C, si está disponible)
+
+---
+
+## Ejemplo de panel Lovelace
+
+```yaml
+type: vertical-stack
+cards:
+  - type: gauge
+    name: VPS1 CPU
+    entity: sensor.vps1_cpu
+  - type: gauge
+    name: VPS1 Memory
+    entity: sensor.vps1_mem
+  - type: entities
+    title: VPS1 Details
+    entities:
+      - sensor.vps1_disk
+      - sensor.vps1_net_in
+      - sensor.vps1_net_out
+      - sensor.vps1_uptime
+      - sensor.vps1_temp
+```
+
+## Notas de seguridad
+- Se recomienda crear un usuario dedicado y restringido para la supervisión por SSH (con acceso de solo lectura a `/proc` y `df`).
+- Se admite autenticación por contraseña, pero se recomienda encarecidamente la **autenticación por clave SSH** para uso en producción.
+- El tráfico de red entre Home Assistant y tus servidores no está cifrado a menos que habilites TLS para MQTT.
+
+---
+
+## Requisitos
+- Home Assistant con broker MQTT (Mosquitto integrado o externo).
+- Acceso SSH a los servidores monitorizados.
+- Servidores de destino basados en Linux (cualquier distribución con `/proc` y `df`).
+
+---
+
+## Licencia
+Este proyecto está licenciado bajo la **Licencia MIT**.
+
+---
+
+## Autor
+**Tony Brüser**
+Autor original y mantenedor de este complemento.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,158 @@
+# VServer SSH Stats – Module complémentaire pour Home Assistant
+
+## Vue d'ensemble
+Le module complémentaire **VServer SSH Stats** pour Home Assistant permet de surveiller des serveurs Linux distants (vServers, Raspberry Pi ou machines dédiées) sans installer de logiciels supplémentaires sur les machines cibles.
+
+Le module se connecte via **SSH** (en utilisant l'adresse IP, le nom d'utilisateur et le mot de passe ou une clé SSH) et collecte les métriques système directement depuis `/proc`, `df` et d'autres interfaces Linux standard.
+Les métriques sont ensuite publiées vers Home Assistant via **MQTT Discovery**, de sorte qu'elles apparaissent comme des capteurs natifs.
+
+Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque, temps de fonctionnement, débit réseau et température de tous vos serveurs dans les tableaux de bord Home Assistant.
+
+---
+
+## Fonctionnalités
+- Aucun logiciel à installer sur le serveur cible (simple accès SSH).
+- Prise en charge de plusieurs serveurs avec configuration individuelle.
+- Prise en charge de l'authentification par mot de passe et par clé SSH.
+- Collecte :
+  - Utilisation du CPU (%)
+  - Utilisation de la mémoire (%)
+  - Utilisation du disque (% pour `/`)
+  - Débit réseau (octets/s, entrant et sortant)
+  - Temps de fonctionnement (secondes)
+  - Température (°C, si disponible)
+- **MQTT Discovery** automatique pour une intégration facile avec Home Assistant.
+- Intervalle de mise à jour configurable (par défaut : 30 secondes).
+
+### Utilisation autonome sans MQTT
+
+Si vous souhaitez recueillir des statistiques sans MQTT, exécutez `app/simple_collector.py`. Le script permet d'entrer un ou plusieurs serveurs (appuyez sur Entrée au prompt de l'hôte pour terminer). Pour chaque serveur, il demande l'hôte, le nom d'utilisateur et soit un mot de passe soit le chemin vers une clé SSH, plus un port optionnel, puis affiche toutes les 30 secondes une ligne JSON incluant le nom du serveur avec les valeurs de CPU, mémoire, disque, réseau, temps de fonctionnement et température.
+
+Vous pouvez facultativement entrer l'URL de base de Home Assistant et un jeton d'accès longue durée. Lorsque ces informations sont fournies, le script crée via l'API REST de Home Assistant des capteurs comme `sensor.<name>_cpu`, `sensor.<name>_mem`, etc., afin que les valeurs apparaissent dans l'interface sans MQTT.
+
+Le collecteur principal (`app/collector.py`) prend également en charge un mode léger sans MQTT : exécutez-le simplement sans la variable d'environnement `MQTT_HOST`. Dans ce cas, les statistiques collectées sont enregistrées sur la console au lieu d'être publiées sur un broker.
+
+---
+
+## Installation
+
+### Via HACS (Home Assistant Community Store)
+1. Assurez-vous que [HACS](https://hacs.xyz) est installé dans Home Assistant.
+2. Dans HACS, ajoutez `https://github.com/404GamerNotFound/vserver-ssh-stats` comme dépôt personnalisé (type : integration).
+3. Recherchez **VServer SSH Stats** et installez l'intégration.
+4. Redémarrez Home Assistant pour charger la nouvelle intégration.
+
+### Installation manuelle du module complémentaire
+1. Copiez le dossier du module `vserver_ssh_stats` dans votre dépôt local de modules complémentaires Home Assistant (par exemple `/addons/vserver_ssh_stats`).
+
+2. Dans Home Assistant :
+   - Accédez à **Paramètres → Add-ons → Add-on Store**.
+   - Cliquez sur le menu à trois points → **Repositories**.
+   - Ajoutez le chemin de votre dépôt local de modules ou le dépôt Git contenant ce module.
+
+3. Le module **VServer SSH Stats** devrait maintenant apparaître dans la liste. Cliquez sur **Install**.
+
+4. Configurez le module (voir ci-dessous).
+
+5. Démarrez le module.
+
+6. Après un court instant, de nouvelles entités (capteurs) apparaîtront automatiquement dans Home Assistant via MQTT Discovery.
+
+---
+
+## Configuration
+
+La configuration est stockée dans `options.json` (modifiable via l'interface du module).
+
+Exemple :
+
+```yaml
+mqtt_host: homeassistant
+mqtt_port: 1883
+mqtt_user: mqttuser
+mqtt_pass: mqttpassword
+interval_seconds: 30
+servers:
+  - name: "pi5"
+    host: "192.168.1.10"
+    username: "tony"
+    password: "supersecret"
+  - name: "vps1"
+    host: "203.0.113.42"
+    username: "root"
+    key: "/config/ssh/id_rsa"
+    port: 22
+```
+
+### Options
+- **mqtt_host** – Nom d'hôte/IP de votre broker MQTT (généralement `homeassistant`).
+- **mqtt_port** – Port du broker MQTT (par défaut : `1883`).
+- **mqtt_user / mqtt_pass** – Identifiants MQTT.
+- **interval_seconds** – Intervalle d'interrogation en secondes (minimum 5).
+- **servers** – Liste des serveurs à surveiller :
+  - `name` – Nom convivial (utilisé comme préfixe d'entité).
+  - `host` – Adresse IP ou nom d'hôte du serveur.
+  - `username` – Nom d'utilisateur SSH.
+  - `password` – Mot de passe SSH (facultatif si `key` est utilisé).
+  - `key` – Chemin vers un fichier de clé privée SSH (facultatif).
+  - `port` – (Facultatif) Port SSH (par défaut `22`).
+
+---
+
+## Entités créées
+
+Pour chaque serveur, les entités suivantes seront disponibles :
+
+- `sensor.<name>_cpu` – Utilisation du CPU (%)
+- `sensor.<name>_mem` – Utilisation de la mémoire (%)
+- `sensor.<name>_disk` – Utilisation du disque (%)
+- `sensor.<name>_net_in` – Trafic entrant (octets/s)
+- `sensor.<name>_net_out` – Trafic sortant (octets/s)
+- `sensor.<name>_uptime` – Temps de fonctionnement (secondes)
+- `sensor.<name>_temp` – Température (°C, si disponible)
+
+---
+
+## Exemple de tableau de bord Lovelace
+
+```yaml
+type: vertical-stack
+cards:
+  - type: gauge
+    name: VPS1 CPU
+    entity: sensor.vps1_cpu
+  - type: gauge
+    name: VPS1 Memory
+    entity: sensor.vps1_mem
+  - type: entities
+    title: VPS1 Details
+    entities:
+      - sensor.vps1_disk
+      - sensor.vps1_net_in
+      - sensor.vps1_net_out
+      - sensor.vps1_uptime
+      - sensor.vps1_temp
+```
+
+## Notes de sécurité
+- Il est recommandé de créer un utilisateur dédié et restreint pour la surveillance SSH (avec un accès en lecture seule à `/proc` et `df`).
+- L'authentification par mot de passe est prise en charge, mais l'**authentification par clé SSH** est fortement recommandée pour un usage en production.
+- Le trafic réseau entre Home Assistant et vos serveurs n'est pas chiffré à moins d'activer TLS pour MQTT.
+
+---
+
+## Exigences
+- Home Assistant avec broker MQTT (Mosquitto intégré ou externe).
+- Accès SSH aux serveurs surveillés.
+- Serveurs cibles basés sur Linux (toute distribution avec `/proc` et `df`).
+
+---
+
+## Licence
+Ce projet est sous licence **MIT**.
+
+---
+
+## Auteur
+**Tony Brüser**
+Auteur original et mainteneur de ce module.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VServer SSH Stats – Home Assistant Add-on
 
+[Deutsch](README.de.md) | [Español](README.es.md) | [Français](README.fr.md)
+
 ## Overview
 The **VServer SSH Stats** add-on for Home Assistant allows you to monitor remote Linux servers (vServers, Raspberry Pi, or dedicated machines) without installing any additional agents on the target machines.  
 

--- a/custom_components/vserver_ssh_stats/translations/de.json
+++ b/custom_components/vserver_ssh_stats/translations/de.json
@@ -1,0 +1,3 @@
+{
+  "title": "VServer SSH Statistiken"
+}

--- a/custom_components/vserver_ssh_stats/translations/es.json
+++ b/custom_components/vserver_ssh_stats/translations/es.json
@@ -1,0 +1,3 @@
+{
+  "title": "Estadísticas SSH de VServer"
+}

--- a/custom_components/vserver_ssh_stats/translations/fr.json
+++ b/custom_components/vserver_ssh_stats/translations/fr.json
@@ -1,0 +1,3 @@
+{
+  "title": "Statistiques SSH de VServer"
+}

--- a/info.de.md
+++ b/info.de.md
@@ -1,0 +1,5 @@
+# VServer SSH Stats
+
+Überwache entfernte Linux-Server über SSH und veröffentliche Metriken per MQTT an Home Assistant.
+
+Ausführliche Installations- und Konfigurationsanweisungen findest du in der [README](README.md).

--- a/info.es.md
+++ b/info.es.md
@@ -1,0 +1,5 @@
+# VServer SSH Stats
+
+Supervisa servidores Linux remotos mediante SSH y publica métricas en Home Assistant a través de MQTT.
+
+Para obtener instrucciones completas de instalación y configuración, consulta el [README](README.md).

--- a/info.fr.md
+++ b/info.fr.md
@@ -1,0 +1,5 @@
+# VServer SSH Stats
+
+Surveillez des serveurs Linux distants via SSH et publiez des métriques vers Home Assistant via MQTT.
+
+Pour des instructions complètes d'installation et de configuration, consultez le [README](README.md).

--- a/info.md
+++ b/info.md
@@ -1,5 +1,7 @@
 # VServer SSH Stats
 
+[Deutsch](info.de.md) | [Español](info.es.md) | [Français](info.fr.md)
+
 Monitor remote Linux servers over SSH and publish metrics to Home Assistant via MQTT.
 
 For full installation and configuration instructions, see the [README](README.md).


### PR DESCRIPTION
## Summary
- Provide German, Spanish, and French translations of README and info docs
- Add matching translation files for the Home Assistant component
- Link available languages from the main docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b54387fd788327b75a23796c934b42