### PR TITLE
Extend server stats with system details

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -17,10 +17,14 @@ Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurch
 - Sammelt:
   - CPU-Auslastung (%)
   - Speicherauslastung (%)
+  - Gesamter RAM (MB)
   - Festplattenauslastung (% für `/`)
   - Netzwerkdurchsatz (Bytes/s, ein- und ausgehend)
   - Laufzeit (Sekunden)
   - Temperatur (°C, falls verfügbar)
+  - CPU-Kerne
+  - Betriebssystem-Version
+  - Installierte Pakete (Anzahl und Liste)
 - Automatische **MQTT Discovery** für einfache Integration in Home Assistant.
 - Konfigurierbares Aktualisierungsintervall (Standard: 30 Sekunden).
 
@@ -110,6 +114,11 @@ Für jeden Server sind folgende Entitäten verfügbar:
 - `sensor.<name>_net_out` – Netzwerkausgang (Bytes/s)
 - `sensor.<name>_uptime` – Laufzeit (Sekunden)
 - `sensor.<name>_temp` – Temperatur (°C, falls verfügbar)
+- `sensor.<name>_ram` – Gesamt-RAM (MB)
+- `sensor.<name>_cores` – CPU-Kerne
+- `sensor.<name>_os` – Betriebssystem-Version
+- `sensor.<name>_pkg_count` – Anzahl installierter Pakete
+- `sensor.<name>_pkg_list` – Installierte Pakete (erste 10)
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -17,10 +17,14 @@ Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiem
 - Recopila:
   - Uso de CPU (%)
   - Uso de memoria (%)
+  - RAM total (MB)
   - Uso de disco (% para `/`)
   - Rendimiento de red (bytes/s de entrada y salida)
   - Tiempo de actividad (segundos)
   - Temperatura (°C, si está disponible)
+  - Núcleos de CPU
+  - Versión del sistema operativo
+  - Paquetes instalados (cantidad y lista)
 - **MQTT Discovery** automática para una fácil integración con Home Assistant.
 - Intervalo de actualización configurable (por defecto: 30 segundos).
 
@@ -110,6 +114,11 @@ Para cada servidor estarán disponibles las siguientes entidades:
 - `sensor.<name>_net_out` – Tráfico de salida (bytes/s)
 - `sensor.<name>_uptime` – Tiempo de actividad (segundos)
 - `sensor.<name>_temp` – Temperatura (°C, si está disponible)
+- `sensor.<name>_ram` – RAM total (MB)
+- `sensor.<name>_cores` – Núcleos de CPU
+- `sensor.<name>_os` – Versión del sistema operativo
+- `sensor.<name>_pkg_count` – Cantidad de paquetes instalados
+- `sensor.<name>_pkg_list` – Paquetes instalados (primeros 10)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -17,10 +17,14 @@ Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque,
 - Collecte :
   - Utilisation du CPU (%)
   - Utilisation de la mémoire (%)
+  - RAM totale (MB)
   - Utilisation du disque (% pour `/`)
   - Débit réseau (octets/s, entrant et sortant)
   - Temps de fonctionnement (secondes)
   - Température (°C, si disponible)
+  - Cœurs CPU
+  - Version du système d'exploitation
+  - Paquets installés (nombre et liste)
 - **MQTT Discovery** automatique pour une intégration facile avec Home Assistant.
 - Intervalle de mise à jour configurable (par défaut : 30 secondes).
 
@@ -110,6 +114,11 @@ Pour chaque serveur, les entités suivantes seront disponibles :
 - `sensor.<name>_net_out` – Trafic sortant (octets/s)
 - `sensor.<name>_uptime` – Temps de fonctionnement (secondes)
 - `sensor.<name>_temp` – Température (°C, si disponible)
+- `sensor.<name>_ram` – RAM totale (MB)
+- `sensor.<name>_cores` – Cœurs CPU
+- `sensor.<name>_os` – Version du système d'exploitation
+- `sensor.<name>_pkg_count` – Nombre de paquets installés
+- `sensor.<name>_pkg_list` – Paquets installés (10 premiers)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ This makes it possible to get real-time CPU, memory, disk, uptime, network throu
 - Collects:
   - CPU usage (%)
   - Memory usage (%)
+  - Total RAM (MB)
   - Disk usage (% for `/`)
   - Network throughput (bytes/s, in and out)
   - Uptime (seconds)
-  - Temperature (°C, if available)  
+  - Temperature (°C, if available)
+  - CPU cores
+  - Operating system version
+  - Installed packages (count and list)
 - Automatic **MQTT Discovery** for easy integration with Home Assistant.
 - Configurable update interval (default: 30 seconds).
 
@@ -109,11 +113,16 @@ For each server, the following entities will be available:
 
 - `sensor.<name>_cpu` – CPU usage (%)  
 - `sensor.<name>_mem` – Memory usage (%)  
-- `sensor.<name>_disk` – Disk usage (%)  
-- `sensor.<name>_net_in` – Network inbound (bytes/s)  
-- `sensor.<name>_net_out` – Network outbound (bytes/s)  
-- `sensor.<name>_uptime` – Uptime (seconds)  
-- `sensor.<name>_temp` – Temperature (°C, if available)  
+- `sensor.<name>_disk` – Disk usage (%)
+- `sensor.<name>_net_in` – Network inbound (bytes/s)
+- `sensor.<name>_net_out` – Network outbound (bytes/s)
+- `sensor.<name>_uptime` – Uptime (seconds)
+- `sensor.<name>_temp` – Temperature (°C, if available)
+- `sensor.<name>_ram` – Total RAM (MB)
+- `sensor.<name>_cores` – CPU cores
+- `sensor.<name>_os` – Operating system version
+- `sensor.<name>_pkg_count` – Installed package count
+- `sensor.<name>_pkg_list` – Installed packages (first 10)
 
 ---
 

--- a/vserver_ssh_stats/app/collector.py
+++ b/vserver_ssh_stats/app/collector.py
@@ -84,6 +84,11 @@ def ensure_discovery(name: str):
         ("net_out", "B/s", None),
         ("uptime", "s", "duration"),
         ("temp", "°C", "temperature"),
+        ("ram", "MB", None),
+        ("cores", None, None),
+        ("os", None, None),
+        ("pkg_count", None, None),
+        ("pkg_list", None, None),
     ]:
         publish_discovery(name, key, unit, dc)
 
@@ -138,12 +143,33 @@ mem_total=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 mem_avail=$(awk '/MemAvailable/ {print $2}' /proc/meminfo)
 if [ -z "$mem_avail" ]; then mem_avail=$(awk '/MemFree/ {print $2}' /proc/meminfo); fi
 mem=$(( (100*(mem_total - mem_avail) + mem_total/2) / mem_total ))
+# RAM total MB
+ram=$(( (mem_total + 512) / 1024 ))
 
 # DISK % (Root)
 disk=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
 
 # UPTIME (Sekunden)
 uptime=$(awk '{print int($1)}' /proc/uptime)
+
+# CPU cores
+cores=$(nproc)
+
+# OS (best-effort)
+os=$( (grep '^PRETTY_NAME' /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"') || uname -sr )
+os_json=$(printf '%s' "$os" | sed 's/"/\\"/g')
+
+# Installed packages (count + list up to 10)
+pkg_count=0
+pkg_list=""
+if command -v dpkg >/dev/null 2>&1; then
+  pkg_count=$(dpkg-query -f '.\n' -W | wc -l)
+  pkg_list=$(dpkg-query -f '${binary:Package}\n' -W | head -n 10 | tr '\n' ',' | sed 's/,$//')
+elif command -v rpm >/dev/null 2>&1; then
+  pkg_count=$(rpm -qa | wc -l)
+  pkg_list=$(rpm -qa | head -n 10 | tr '\n' ',' | sed 's/,$//')
+fi
+pkg_list_json=$(printf '%s' "$pkg_list" | sed 's/"/\\"/g')
 
 # TEMP (°C, best-effort)
 temp=""
@@ -157,8 +183,8 @@ rx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print rx+0}' /proc/ne
 tx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print tx+0}' /proc/net/dev)
 
 if [ -n "$temp" ]; then temp_json=$temp; else temp_json=null; fi
-printf '{"cpu":%s,"mem":%s,"disk":%s,"uptime":%s,"temp":%s,"rx":%s,"tx":%s}\n' \
-  "$cpu" "$mem" "$disk" "$uptime" "$temp_json" "$rx" "$tx"
+printf '{"cpu":%s,"mem":%s,"disk":%s,"uptime":%s,"temp":%s,"rx":%s,"tx":%s,"ram":%s,"cores":%s,"os":"%s","pkg_count":%s,"pkg_list":"%s"}\n' \
+  "$cpu" "$mem" "$disk" "$uptime" "$temp_json" "$rx" "$tx" "$ram" "$cores" "$os_json" "$pkg_count" "$pkg_list_json"
 '''
 
 def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:
@@ -192,6 +218,11 @@ def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:
         "temp": (None if data["temp"] is None else float(data["temp"])),
         "net_in": round(net_in, 2),
         "net_out": round(net_out, 2),
+        "ram": int(data.get("ram", 0)),
+        "cores": int(data.get("cores", 0)),
+        "os": data.get("os", ""),
+        "pkg_count": int(data.get("pkg_count", 0)),
+        "pkg_list": data.get("pkg_list", ""),
     }
 
 def main():
@@ -246,6 +277,11 @@ def main():
                     "temp": None,
                     "net_in": 0,
                     "net_out": 0,
+                    "ram": 0,
+                    "cores": 0,
+                    "os": "",
+                    "pkg_count": 0,
+                    "pkg_list": "",
                 }
                 if client:
                     client.publish(


### PR DESCRIPTION
## Summary
- collect RAM size, CPU core count, OS version, and installed package info from monitored servers
- expose the new fields via MQTT discovery and simple collector output
- document additional sensors in all readme translations

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py vserver_ssh_stats/app/simple_collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b569ade1bc83279c66c208c521e243