### PR TITLE
feat: allow disabling sensors via settings

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -77,6 +77,9 @@ mqtt_port: 1883
 mqtt_user: mqttuser
 mqtt_pass: mqttpassword
 interval_seconds: 30
+disabled_entities:
+  - pkg_list
+  - temp
 servers:
   - name: "pi5"
     host: "192.168.1.10"
@@ -94,6 +97,7 @@ servers:
 - **mqtt_port** – Port des MQTT-Brokers (Standard: `1883`).
 - **mqtt_user / mqtt_pass** – MQTT-Anmeldedaten.
 - **interval_seconds** – Abfrageintervall in Sekunden (mindestens 5).
+- **disabled_entities** – Liste von Sensor-Schlüsseln, die deaktiviert werden sollen (z. B. `cpu`, `mem`). Standard: alle aktiv.
 - **servers** – Liste der zu überwachenden Server:
   - `name` – Anzeigename (wird als Präfix für Entitäten verwendet).
   - `host` – IP-Adresse oder Hostname des Servers.
@@ -101,6 +105,17 @@ servers:
   - `password` – SSH-Passwort (optional, wenn `key` verwendet wird).
   - `key` – Pfad zu einer SSH-Schlüsseldatei (optional).
   - `port` – (Optional) SSH-Port (Standard `22`).
+
+### Entitäten deaktivieren
+
+Um bestimmte Sensoren nicht zu erstellen und zu veröffentlichen, füge deren Schlüssel zu `disabled_entities` hinzu. Beispiel: Um
+Temperatur- und Paketlisten-Sensoren zu deaktivieren:
+
+```yaml
+disabled_entities:
+  - temp
+  - pkg_list
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ mqtt_port: 1883
 mqtt_user: mqttuser
 mqtt_pass: mqttpassword
 interval_seconds: 30
+disabled_entities:
+  - pkg_list
+  - temp
 servers:
   - name: "pi5"
     host: "192.168.1.10"
@@ -98,14 +101,26 @@ servers:
 - **mqtt_host** – Hostname/IP of your MQTT broker (usually `homeassistant`).  
 - **mqtt_port** – Port of the MQTT broker (default: `1883`).  
 - **mqtt_user / mqtt_pass** – MQTT credentials.  
-- **interval_seconds** – Polling interval in seconds (minimum 5).  
-- **servers** – List of servers to monitor:  
-  - `name` – Friendly name (used as entity prefix).  
+- **interval_seconds** – Polling interval in seconds (minimum 5).
+- **disabled_entities** – List of sensor keys to disable (e.g. `cpu`, `mem`). All entities enabled by default.
+- **servers** – List of servers to monitor:
+  - `name` – Friendly name (used as entity prefix).
   - `host` – IP address or hostname of the server.
   - `username` – SSH username.
   - `password` – SSH password (optional if `key` is used).
   - `key` – Path to an SSH private key file (optional).
   - `port` – (Optional) SSH port (default `22`).
+
+### Disabling entities
+
+Add unwanted sensor keys to `disabled_entities` to skip creating and publishing them. For example, to disable the temperature and
+package list sensors:
+
+```yaml
+disabled_entities:
+  - temp
+  - pkg_list
+```
 
 ---
 

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.15"
+version: "0.1.16"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services
@@ -20,6 +20,7 @@ options:
   mqtt_user: ""
   mqtt_pass: ""
   interval_seconds: 30
+  disabled_entities: []
   servers:
     - name: "vps1"
       host: "203.0.113.10"
@@ -33,6 +34,8 @@ schema:
   mqtt_user: str
   mqtt_pass: str
   interval_seconds: int
+  disabled_entities:
+    - match(cpu|mem|disk|net_in|net_out|uptime|temp|ram|cores|os|pkg_count|pkg_list)
   servers:
     - name: str
       host: str

--- a/vserver_ssh_stats/run.sh
+++ b/vserver_ssh_stats/run.sh
@@ -9,6 +9,7 @@ export MQTT_USER=$(jq -r .mqtt_user ${CONFIG_PATH})
 export MQTT_PASS=$(jq -r .mqtt_pass ${CONFIG_PATH})
 export INTERVAL=$(jq -r .interval_seconds ${CONFIG_PATH})
 export SERVERS_JSON=$(jq -c .servers ${CONFIG_PATH})
+export DISABLED_JSON=$(jq -c '.disabled_entities // []' ${CONFIG_PATH})
 
 # Start lightweight web server for optional sidebar access
 python3 -m http.server 8099 --directory /app/web &


### PR DESCRIPTION
## Summary
- allow disabling individual metrics via add-on option `disabled_entities`
- document new `disabled_entities` option with example

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py`
- `bash -n vserver_ssh_stats/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b662f973a08327bdeeb37a92e17e9c