### PR TITLE
Add Docker container listing and tab

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -25,9 +25,10 @@ Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurch
   - CPU-Kerne
   - Betriebssystem-Version
   - Installierte Pakete (Anzahl und Liste)
+  - Docker-Installation und laufende Container
 - Automatische **MQTT Discovery** für einfache Integration in Home Assistant.
 - Konfigurierbares Aktualisierungsintervall (Standard: 30 Sekunden).
-- Optionale leichtgewichtige Weboberfläche, die in der Home-Assistant-Seitenleiste angezeigt werden kann.
+- Optionale leichtgewichtige Weboberfläche, die in der Home-Assistant-Seitenleiste angezeigt werden kann, jetzt mit einem Reiter für Docker-Container.
 
 ### Standalone-Nutzung ohne MQTT
 
@@ -135,6 +136,8 @@ Für jeden Server sind folgende Entitäten verfügbar:
 - `sensor.<name>_os` – Betriebssystem-Version
 - `sensor.<name>_pkg_count` – Anzahl installierter Pakete
 - `sensor.<name>_pkg_list` – Installierte Pakete (erste 10)
+- `sensor.<name>_docker` – 1, wenn Docker installiert ist, sonst 0
+- `sensor.<name>_containers` – Laufende Docker-Container (kommagetrennte Liste)
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -25,9 +25,10 @@ Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiem
   - Núcleos de CPU
   - Versión del sistema operativo
   - Paquetes instalados (cantidad y lista)
+  - Detección de Docker y contenedores en ejecución
 - **MQTT Discovery** automática para una fácil integración con Home Assistant.
 - Intervalo de actualización configurable (por defecto: 30 segundos).
-- Interfaz web ligera opcional que puede mostrarse en la barra lateral de Home Assistant.
+- Interfaz web ligera opcional que puede mostrarse en la barra lateral de Home Assistant, ahora con una pestaña de contenedores Docker.
 
 ### Uso independiente sin MQTT
 
@@ -120,6 +121,8 @@ Para cada servidor estarán disponibles las siguientes entidades:
 - `sensor.<name>_os` – Versión del sistema operativo
 - `sensor.<name>_pkg_count` – Cantidad de paquetes instalados
 - `sensor.<name>_pkg_list` – Paquetes instalados (primeros 10)
+- `sensor.<name>_docker` – 1 si Docker está instalado, 0 en caso contrario
+- `sensor.<name>_containers` – Contenedores Docker en ejecución (lista separada por comas)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -25,9 +25,10 @@ Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque,
   - Cœurs CPU
   - Version du système d'exploitation
   - Paquets installés (nombre et liste)
+  - Détection de Docker et conteneurs en cours d'exécution
 - **MQTT Discovery** automatique pour une intégration facile avec Home Assistant.
 - Intervalle de mise à jour configurable (par défaut : 30 secondes).
-- Interface web légère optionnelle pouvant être affichée dans la barre latérale de Home Assistant.
+- Interface web légère optionnelle pouvant être affichée dans la barre latérale de Home Assistant, maintenant avec un onglet pour les conteneurs Docker.
 
 ### Utilisation autonome sans MQTT
 
@@ -120,6 +121,8 @@ Pour chaque serveur, les entités suivantes seront disponibles :
 - `sensor.<name>_os` – Version du système d'exploitation
 - `sensor.<name>_pkg_count` – Nombre de paquets installés
 - `sensor.<name>_pkg_list` – Paquets installés (10 premiers)
+- `sensor.<name>_docker` – 1 si Docker est installé, 0 sinon
+- `sensor.<name>_containers` – Conteneurs Docker en cours d'exécution (liste séparée par des virgules)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ This makes it possible to get real-time CPU, memory, disk, uptime, network throu
   - CPU cores
   - Operating system version
   - Installed packages (count and list)
+  - Docker installation and running containers
 - Automatic **MQTT Discovery** for easy integration with Home Assistant.
 - Configurable update interval (default: 30 seconds).
-- Optional lightweight web interface that can be shown in the Home Assistant sidebar.
+- Optional lightweight web interface that can be shown in the Home Assistant sidebar, now with a Docker container tab.
 - Services to fetch the server's local IP, uptime, and list active SSH connections.
 
 ### Standalone Usage Without MQTT
@@ -140,6 +141,8 @@ For each server, the following entities will be available:
 - `sensor.<name>_os` – Operating system version
 - `sensor.<name>_pkg_count` – Installed package count
 - `sensor.<name>_pkg_list` – Installed packages (first 10)
+- `sensor.<name>_docker` – 1 if Docker is installed, 0 otherwise
+- `sensor.<name>_containers` – Running Docker containers (comma-separated list)
 
 ---
 

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "0.1.18"
+  "version": "0.1.19"
 }

--- a/info.de.md
+++ b/info.de.md
@@ -2,5 +2,6 @@
 
 Überwache entfernte Linux-Server über SSH und veröffentliche Metriken per MQTT an Home Assistant.
 Zusätzliche Dienste geben die lokale IP-Adresse des Servers, die Systemlaufzeit sowie aktuell aktive SSH-Verbindungen aus.
+Erkennt außerdem, ob Docker installiert ist, und listet laufende Container auf.
 
 Ausführliche Installations- und Konfigurationsanweisungen findest du in der [README](README.md).

--- a/info.es.md
+++ b/info.es.md
@@ -2,5 +2,6 @@
 
 Supervisa servidores Linux remotos mediante SSH y publica métricas en Home Assistant a través de MQTT.
 Servicios adicionales exponen la dirección IP local del servidor, el tiempo de actividad del sistema y las conexiones SSH activas.
+También detecta si Docker está instalado y muestra los contenedores en ejecución.
 
 Para obtener instrucciones completas de instalación y configuración, consulta el [README](README.md).

--- a/info.fr.md
+++ b/info.fr.md
@@ -2,5 +2,6 @@
 
 Surveillez des serveurs Linux distants via SSH et publiez des métriques vers Home Assistant via MQTT.
 Des services supplémentaires exposent l'adresse IP locale du serveur, le temps de fonctionnement du système et les connexions SSH actives.
+Détecte également si Docker est installé et affiche les conteneurs en cours d'exécution.
 
 Pour des instructions complètes d'installation et de configuration, consultez le [README](README.md).

--- a/info.md
+++ b/info.md
@@ -4,5 +4,6 @@
 
 Monitor remote Linux servers over SSH and publish metrics to Home Assistant via MQTT.
 Additional services expose the server's local IP address, system uptime, and currently active SSH connections.
+Now also reports whether Docker is installed and lists running containers.
 
 For full installation and configuration instructions, see the [README](README.md).

--- a/vserver_ssh_stats/app/collector.py
+++ b/vserver_ssh_stats/app/collector.py
@@ -102,6 +102,8 @@ def ensure_discovery(name: str) -> None:
         ("os", None, None, True),
         ("pkg_count", None, None, False),
         ("pkg_list", None, None, True),
+        ("docker", None, None, False),
+        ("containers", None, None, True),
     ]:
         if key in DISABLED_ENTITIES:
             continue
@@ -186,6 +188,16 @@ elif command -v rpm >/dev/null 2>&1; then
 fi
 pkg_list_json=$(printf '%s' "$pkg_list" | sed 's/"/\\"/g')
 
+# Docker (installed and running containers)
+if command -v docker >/dev/null 2>&1; then
+  docker=1
+  containers=$(docker ps --format '{{.Names}}' | tr '\n' ',' | sed 's/,$//')
+else
+  docker=0
+  containers=""
+fi
+containers_json=$(printf '%s' "$containers" | sed 's/"/\\"/g')
+
 # TEMP (°C, best-effort)
 temp=""
 if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
@@ -198,8 +210,8 @@ rx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print rx+0}' /proc/ne
 tx=$(awk -F'[: ]+' '/:/{if($1!="lo"){rx+=$3; tx+=$11}} END{print tx+0}' /proc/net/dev)
 
 if [ -n "$temp" ]; then temp_json=$temp; else temp_json=null; fi
-printf '{"cpu":%s,"mem":%s,"disk":%s,"uptime":%s,"temp":%s,"rx":%s,"tx":%s,"ram":%s,"cores":%s,"os":"%s","pkg_count":%s,"pkg_list":"%s"}\n' \
-  "$cpu" "$mem" "$disk" "$uptime" "$temp_json" "$rx" "$tx" "$ram" "$cores" "$os_json" "$pkg_count" "$pkg_list_json"
+printf '{"cpu":%s,"mem":%s,"disk":%s,"uptime":%s,"temp":%s,"rx":%s,"tx":%s,"ram":%s,"cores":%s,"os":"%s","pkg_count":%s,"pkg_list":"%s","docker":%s,"containers":"%s"}\n' \
+  "$cpu" "$mem" "$disk" "$uptime" "$temp_json" "$rx" "$tx" "$ram" "$cores" "$os_json" "$pkg_count" "$pkg_list_json" "$docker" "$containers_json"
 '''
 
 def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:
@@ -238,6 +250,8 @@ def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:
         "os": data.get("os", ""),
         "pkg_count": int(data.get("pkg_count", 0)),
         "pkg_list": data.get("pkg_list", ""),
+        "docker": int(data.get("docker", 0)),
+        "containers": data.get("containers", ""),
     }
 
 def main():
@@ -302,6 +316,8 @@ def main():
                     "os": "",
                     "pkg_count": 0,
                     "pkg_list": "",
+                    "docker": 0,
+                    "containers": "",
                 }
                 err_payload = err.copy()
                 for k in DISABLED_ENTITIES:

--- a/vserver_ssh_stats/app/web/index.html
+++ b/vserver_ssh_stats/app/web/index.html
@@ -4,7 +4,11 @@
   <meta charset="UTF-8" />
   <title>VServer SSH Stats</title>
   <style>
-    body { font-family: Arial, sans-serif; background:#1e1e1e; color:#e0e0e0; margin:0; padding:1em; }
+    body { font-family: Arial, sans-serif; background:#1e1e1e; color:#e0e0e0; margin:0; }
+    #sidenav { position:fixed; top:0; left:0; width:200px; height:100%; background:#111; padding-top:20px; }
+    #sidenav a { padding:8px 16px; text-decoration:none; display:block; color:#818181; }
+    #sidenav a:hover { color:#f1f1f1; }
+    #main { margin-left:200px; padding:1em; }
     h1 { text-align:center; }
     .server-card { background:#2b2b2b; border:1px solid #444; border-radius:8px; padding:1em; margin:1em auto; max-width:600px; }
     .server-header { font-size:1.2em; margin-bottom:0.5em; }
@@ -13,17 +17,30 @@
   </style>
 </head>
 <body>
-  <h1>VServer SSH Stats</h1>
-  <div id="servers"></div>
+  <div id="sidenav">
+    <a href="#" onclick="showTab('stats')">Server Stats</a>
+    <a href="#" onclick="showTab('docker')">Docker Container</a>
+  </div>
+  <div id="main">
+    <h1>VServer SSH Stats</h1>
+    <div id="stats" class="tab"></div>
+    <div id="docker" class="tab" style="display:none;"></div>
+  </div>
   <script>
+    function showTab(name){
+      document.getElementById('stats').style.display = name === 'stats' ? 'block' : 'none';
+      document.getElementById('docker').style.display = name === 'docker' ? 'block' : 'none';
+    }
     function formatBytes(b){const u=['B','K','M','G','T'];let i=0;while(b>=1024&&i<u.length-1){b/=1024;i++;}return b.toFixed(1)+' '+u[i];}
     function formatUptime(sec){const d=Math.floor(sec/86400);sec%=86400;const h=Math.floor(sec/3600);const m=Math.floor((sec%3600)/60);return `${d}d ${h}h ${m}m`;}
     async function load(){
       try {
         const resp = await fetch('stats.json?_=' + Date.now());
         const data = await resp.json();
-        const container = document.getElementById('servers');
-        container.innerHTML='';
+        const statsDiv = document.getElementById('stats');
+        const dockerDiv = document.getElementById('docker');
+        statsDiv.innerHTML='';
+        dockerDiv.innerHTML='';
         data.forEach(s => {
           const card = document.createElement('div');
           card.className = 'server-card';
@@ -34,7 +51,19 @@
             <div class="metric">Net ↓ ${formatBytes(s.net_in)}/s ↑ ${formatBytes(s.net_out)}/s</div>
             <div class="metric">Uptime ${formatUptime(s.uptime)}</div>
             <div class="metric">Temp ${s.temp === null ? '—' : s.temp + '°C'}</div>`;
-          container.appendChild(card);
+          statsDiv.appendChild(card);
+          const dcard = document.createElement('div');
+          dcard.className = 'server-card';
+          let list = 'Docker not installed';
+          if (s.docker) {
+            if (s.containers) {
+              list = s.containers.split(',').join(', ');
+            } else {
+              list = 'No containers running';
+            }
+          }
+          dcard.innerHTML = `<div class="server-header">${s.name}</div><div>${list}</div>`;
+          dockerDiv.appendChild(dcard);
         });
       } catch (e) {
         console.error('Failed to load stats', e);

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.16"
+version: "0.1.17"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- detect Docker installation and report running containers in collector
- add Docker Container tab to web interface
- document Docker metrics in readme and info files
- bump add-on and integration versions

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py vserver_ssh_stats/app/simple_collector.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66672b2848327bb023ace567f1607