### PR TITLE
feat: add load averages and cpu frequency metrics

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -23,6 +23,8 @@ Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurch
   - Laufzeit (Sekunden)
   - Temperatur (°C, falls verfügbar)
   - CPU-Kerne
+  - Last (1/5/15 Minuten)
+  - CPU-Frequenz (MHz)
   - Betriebssystem-Version
   - Installierte Pakete (Anzahl und Liste)
   - Docker-Installation und laufende Container
@@ -133,6 +135,10 @@ Für jeden Server sind folgende Entitäten verfügbar:
 - `sensor.<name>_temp` – Temperatur (°C, falls verfügbar)
 - `sensor.<name>_ram` – Gesamt-RAM (MB)
 - `sensor.<name>_cores` – CPU-Kerne
+- `sensor.<name>_load_1` – 1‑Minuten‑Last
+- `sensor.<name>_load_5` – 5‑Minuten‑Last
+- `sensor.<name>_load_15` – 15‑Minuten‑Last
+- `sensor.<name>_cpu_freq` – CPU‑Frequenz (MHz)
 - `sensor.<name>_os` – Betriebssystem-Version
 - `sensor.<name>_pkg_count` – Anzahl installierter Pakete
 - `sensor.<name>_pkg_list` – Installierte Pakete (erste 10)

--- a/README.es.md
+++ b/README.es.md
@@ -23,6 +23,8 @@ Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiem
   - Tiempo de actividad (segundos)
   - Temperatura (°C, si está disponible)
   - Núcleos de CPU
+  - Carga promedio (1/5/15 min)
+  - Frecuencia de CPU (MHz)
   - Versión del sistema operativo
   - Paquetes instalados (cantidad y lista)
   - Detección de Docker y contenedores en ejecución
@@ -118,6 +120,10 @@ Para cada servidor estarán disponibles las siguientes entidades:
 - `sensor.<name>_temp` – Temperatura (°C, si está disponible)
 - `sensor.<name>_ram` – RAM total (MB)
 - `sensor.<name>_cores` – Núcleos de CPU
+- `sensor.<name>_load_1` – Carga promedio 1 min
+- `sensor.<name>_load_5` – Carga promedio 5 min
+- `sensor.<name>_load_15` – Carga promedio 15 min
+- `sensor.<name>_cpu_freq` – Frecuencia de CPU (MHz)
 - `sensor.<name>_os` – Versión del sistema operativo
 - `sensor.<name>_pkg_count` – Cantidad de paquetes instalados
 - `sensor.<name>_pkg_list` – Paquetes instalados (primeros 10)

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,6 +23,8 @@ Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque,
   - Temps de fonctionnement (secondes)
   - Température (°C, si disponible)
   - Cœurs CPU
+  - Charge moyenne (1/5/15 min)
+  - Fréquence CPU (MHz)
   - Version du système d'exploitation
   - Paquets installés (nombre et liste)
   - Détection de Docker et conteneurs en cours d'exécution
@@ -118,6 +120,10 @@ Pour chaque serveur, les entités suivantes seront disponibles :
 - `sensor.<name>_temp` – Température (°C, si disponible)
 - `sensor.<name>_ram` – RAM totale (MB)
 - `sensor.<name>_cores` – Cœurs CPU
+- `sensor.<name>_load_1` – Charge moyenne 1 min
+- `sensor.<name>_load_5` – Charge moyenne 5 min
+- `sensor.<name>_load_15` – Charge moyenne 15 min
+- `sensor.<name>_cpu_freq` – Fréquence CPU (MHz)
 - `sensor.<name>_os` – Version du système d'exploitation
 - `sensor.<name>_pkg_count` – Nombre de paquets installés
 - `sensor.<name>_pkg_list` – Paquets installés (10 premiers)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This makes it possible to get real-time CPU, memory, disk, uptime, network throu
   - Uptime (seconds)
   - Temperature (°C, if available)
   - CPU cores
+  - Load average (1/5/15 min)
+  - CPU frequency (MHz)
   - Operating system version
   - Installed packages (count and list)
   - Docker installation and running containers
@@ -138,6 +140,10 @@ For each server, the following entities will be available:
 - `sensor.<name>_temp` – Temperature (°C, if available)
 - `sensor.<name>_ram` – Total RAM (MB)
 - `sensor.<name>_cores` – CPU cores
+- `sensor.<name>_load_1` – 1‑minute load average
+- `sensor.<name>_load_5` – 5‑minute load average
+- `sensor.<name>_load_15` – 15‑minute load average
+- `sensor.<name>_cpu_freq` – CPU frequency (MHz)
 - `sensor.<name>_os` – Operating system version
 - `sensor.<name>_pkg_count` – Installed package count
 - `sensor.<name>_pkg_list` – Installed packages (first 10)

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -35,7 +35,7 @@ schema:
   mqtt_pass: str
   interval_seconds: int
   disabled_entities:
-    - match(cpu|mem|disk|net_in|net_out|uptime|temp|ram|cores|os|pkg_count|pkg_list)
+    - match(cpu|mem|disk|net_in|net_out|uptime|temp|ram|cores|load_1|load_5|load_15|cpu_freq|os|pkg_count|pkg_list)
   servers:
     - name: str
       host: str


### PR DESCRIPTION
## Summary
- collect load averages and CPU frequency in the SSH collector
- expose new load and cpu_freq sensors via MQTT discovery
- document the additional sensors in README and add-on config

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py`
- Executed bundled REMOTE_SCRIPT locally to verify new metrics


------
https://chatgpt.com/codex/tasks/task_e_68b696566fe0832780d558c30450b0cb