### PR TITLE
Handle missing Docker access in stats collector

### DIFF
--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "0.1.21"
+  "version": "0.1.22"
 }

--- a/vserver_ssh_stats/app/collector.py
+++ b/vserver_ssh_stats/app/collector.py
@@ -229,10 +229,10 @@ fi
 pkg_list_json=$(printf '%s' "$pkg_list" | sed 's/"/\\"/g')
 
 # Docker (installed and running containers)
-if command -v docker >/dev/null 2>&1; then
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   docker=1
-  containers=$(docker ps --format '{{.Names}}' | tr '\n' ',' | sed 's/,$//')
-  stats=$(docker stats --no-stream --format '{{.Name}}:{{.CPUPerc}}:{{.MemPerc}}' | sed 's/%//g' | awk -F: '{printf "{\\"name\\":\\"%s\\",\\"cpu\\":%s,\\"mem\\":%s},", $1, $2, $3}')
+  containers=$(docker ps --format '{{.Names}}' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+  stats=$(docker stats --no-stream --format '{{.Name}}:{{.CPUPerc}}:{{.MemPerc}}' 2>/dev/null | sed 's/%//g' | awk -F: '{printf "{"name":"%s","cpu":%s,"mem":%s},", $1, $2, $3}')
   if [ -n "$stats" ]; then
     container_stats="[${stats%,}]"
   else

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.21"
+version: "0.1.22"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- Skip Docker stats collection when Docker is inaccessible (e.g., protection mode) and keep gathering other metrics
- Fix AWK quoting in Docker stats parsing
- Bump add-on and integration version to 0.1.22

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69b01144083279669003ee936617f