### PR TITLE
Ensure C locale for JSON output

### DIFF
--- a/vserver_ssh_stats/app/collector.py
+++ b/vserver_ssh_stats/app/collector.py
@@ -173,6 +173,8 @@ def run_ssh(
 # Remote-Script: CPU (über /proc/stat doppelt), Mem (/proc/meminfo), Disk (df /), Uptime, Temp (thermal_zone0), Net (bytes um Interface-summen)
 REMOTE_SCRIPT = r'''
 set -e
+export LC_ALL=C
+export LANG=C
 # CPU %
 read cpu user nice system idle iowait irq softirq steal guest < /proc/stat
 prev_total=$((user+nice+system+idle+iowait+irq+softirq+steal))

--- a/vserver_ssh_stats/app/simple_collector.py
+++ b/vserver_ssh_stats/app/simple_collector.py
@@ -50,6 +50,8 @@ def run_ssh(
 
 REMOTE_SCRIPT = r'''
 set -e
+export LC_ALL=C
+export LANG=C
 # CPU %
 read cpu user nice system idle iowait irq softirq steal guest < /proc/stat
 prev_total=$((user+nice+system+idle+iowait+irq+softirq+steal))


### PR DESCRIPTION
## Summary
- enforce C locale in remote stat collection scripts so numeric values use `.` as decimal separator

## Testing
- `python -m py_compile vserver_ssh_stats/app/collector.py vserver_ssh_stats/app/simple_collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69ef518c0832797b53ccc19a9edab