### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/addon/vserver_ssh_stats/config.yaml
+++ b/addon/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "1.0.0"
+version: "1.0.1"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary
- bump integration and add-on versions to 1.0.1 so Home Assistant can detect updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log || true`

------
https://chatgpt.com/codex/tasks/task_e_68b6a7cbfa648327a6d4bcd37d092bd2