### PR TITLE
fix: add build deps

### DIFF
--- a/addon/vserver_ssh_stats/Dockerfile
+++ b/addon/vserver_ssh_stats/Dockerfile
@@ -1,8 +1,10 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.2.2
 FROM ${BUILD_FROM}
 
-RUN apk add --no-cache python3 py3-pip py3-setuptools python3-dev build-base \
-    && pip3 install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
+RUN apk add --no-cache \
+    python3 py3-pip py3-setuptools python3-dev build-base \
+    rust cargo libffi-dev openssl-dev libsodium-dev \
+    && pip3 install --no-cache-dir wheel paramiko paho-mqtt
 
 COPY run.sh /run.sh
 COPY app /app

--- a/addon/vserver_ssh_stats/config.yaml
+++ b/addon/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "0.1.24"
+version: "0.1.26"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "0.1.24"
+  "version": "0.1.26"
 }


### PR DESCRIPTION
## Summary
- ensure required build tools are present for add-on builds
- bump add-on/integration version to 0.1.26

## Testing
- `bash -n addon/vserver_ssh_stats/run.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile addon/vserver_ssh_stats/app/collector.py addon/vserver_ssh_stats/app/simple_collector.py custom_components/vserver_ssh_stats/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a3a567848327a96611aab3341baf