### PR TITLE
fix: restore update detection

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -141,8 +141,8 @@ Für jeden Server sind folgende Entitäten verfügbar:
 - `sensor.<name>_load_15` – 15‑Minuten‑Last
 - `sensor.<name>_cpu_freq` – CPU‑Frequenz (MHz)
 - `sensor.<name>_os` – Betriebssystem-Version
-- `sensor.<name>_pkg_count` – Anzahl installierter Pakete
-- `sensor.<name>_pkg_list` – Installierte Pakete (erste 10)
+- `sensor.<name>_pkg_count` – Anzahl verfügbarer Updates
+- `sensor.<name>_pkg_list` – Verfügbare Updates (erste 10)
 - `sensor.<name>_docker` – 1, wenn Docker installiert ist, sonst 0
 - `sensor.<name>_containers` – Laufende Docker-Container (kommagetrennte Liste)
 

--- a/README.es.md
+++ b/README.es.md
@@ -126,8 +126,8 @@ Para cada servidor estarán disponibles las siguientes entidades:
 - `sensor.<name>_load_15` – Carga promedio 15 min
 - `sensor.<name>_cpu_freq` – Frecuencia de CPU (MHz)
 - `sensor.<name>_os` – Versión del sistema operativo
-- `sensor.<name>_pkg_count` – Cantidad de paquetes instalados
-- `sensor.<name>_pkg_list` – Paquetes instalados (primeros 10)
+- `sensor.<name>_pkg_count` – Cantidad de actualizaciones pendientes
+- `sensor.<name>_pkg_list` – Actualizaciones pendientes (primeras 10)
 - `sensor.<name>_docker` – 1 si Docker está instalado, 0 en caso contrario
 - `sensor.<name>_containers` – Contenedores Docker en ejecución (lista separada por comas)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -126,8 +126,8 @@ Pour chaque serveur, les entités suivantes seront disponibles :
 - `sensor.<name>_load_15` – Charge moyenne 15 min
 - `sensor.<name>_cpu_freq` – Fréquence CPU (MHz)
 - `sensor.<name>_os` – Version du système d'exploitation
-- `sensor.<name>_pkg_count` – Nombre de paquets installés
-- `sensor.<name>_pkg_list` – Paquets installés (10 premiers)
+- `sensor.<name>_pkg_count` – Nombre de mises à jour en attente
+- `sensor.<name>_pkg_list` – Mises à jour en attente (10 premières)
 - `sensor.<name>_docker` – 1 si Docker est installé, 0 sinon
 - `sensor.<name>_containers` – Conteneurs Docker en cours d'exécution (liste séparée par des virgules)
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ For each server, the following entities will be available:
 - `sensor.<name>_load_15` – 15‑minute load average
 - `sensor.<name>_cpu_freq` – CPU frequency (MHz)
 - `sensor.<name>_os` – Operating system version
-- `sensor.<name>_pkg_count` – Installed package count
-- `sensor.<name>_pkg_list` – Installed packages (first 10)
+- `sensor.<name>_pkg_count` – Pending update count
+- `sensor.<name>_pkg_list` – Pending update packages (first 10)
 - `sensor.<name>_docker` – 1 if Docker is installed, 0 otherwise
 - `sensor.<name>_containers` – Running Docker containers (comma-separated list)
 

--- a/addon/vserver_ssh_stats/app/collector.py
+++ b/addon/vserver_ssh_stats/app/collector.py
@@ -218,15 +218,21 @@ if [ -n "$cpu_freq" ]; then cpu_freq_json=$cpu_freq; else cpu_freq_json=null; fi
 os=$( (grep '^PRETTY_NAME' /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"') || uname -sr )
 os_json=$(printf '%s' "$os" | sed 's/"/\\"/g')
 
-# Installed packages (count + list up to 10)
+# Pending package updates (count + list up to 10)
 pkg_count=0
 pkg_list=""
-if command -v dpkg >/dev/null 2>&1; then
-  pkg_count=$(dpkg-query -f '.\n' -W | wc -l)
-  pkg_list=$(dpkg-query -f '${binary:Package}\n' -W | head -n 10 | tr '\n' ',' | sed 's/,$//')
-elif command -v rpm >/dev/null 2>&1; then
-  pkg_count=$(rpm -qa | wc -l)
-  pkg_list=$(rpm -qa | head -n 10 | tr '\n' ',' | sed 's/,$//')
+if command -v apt-get >/dev/null 2>&1; then
+  updates=$(apt-get -s upgrade 2>/dev/null | awk '/^Inst /{print $2}')
+  pkg_count=$(echo "$updates" | wc -l)
+  pkg_list=$(echo "$updates" | head -n 10 | tr '\n' ',' | sed 's/,$//')
+elif command -v dnf >/dev/null 2>&1; then
+  updates=$(dnf -q check-update --refresh 2>/dev/null | awk '/^[[:alnum:].-]+[[:space:]]/ {print $1}')
+  pkg_count=$(echo "$updates" | wc -l)
+  pkg_list=$(echo "$updates" | head -n 10 | tr '\n' ',' | sed 's/,$//')
+elif command -v yum >/dev/null 2>&1; then
+  updates=$(yum -q check-update 2>/dev/null | awk '/^[[:alnum:].-]+[[:space:]]/ {print $1}')
+  pkg_count=$(echo "$updates" | wc -l)
+  pkg_list=$(echo "$updates" | head -n 10 | tr '\n' ',' | sed 's/,$//')
 fi
 pkg_list_json=$(printf '%s' "$pkg_list" | sed 's/"/\\"/g')
 

--- a/addon/vserver_ssh_stats/config.yaml
+++ b/addon/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "1.0.0"
+version: "1.0.1"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary
- count pending OS package updates instead of installed packages
- document new update metrics in README translations
- bump version to 1.0.1

## Testing
- `python -m py_compile addon/vserver_ssh_stats/app/collector.py custom_components/vserver_ssh_stats/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6ac84f7dc8327affa62de4d90bb12