### PR TITLE
fix: allow pip install in Dockerfile

### DIFF
--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BUILD_FROM}
 RUN apk add --no-cache \
     python3 py3-pip py3-setuptools python3-dev build-base \
     rust cargo libffi-dev openssl-dev libsodium-dev \
-    && pip3 install --no-cache-dir wheel paramiko paho-mqtt
+    && pip3 install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
 
 COPY run.sh /run.sh
 COPY app /app


### PR DESCRIPTION
## Summary
- allow pip install by breaking system packages in Dockerfile

## Testing
- `docker build -t test-addon vserver_ssh_stats` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b6cf39a08327b06e7e2f2ea9c278