### PR TITLE
fix: ensure pip installs in addon

### DIFF
--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BUILD_FROM}
 RUN apk add --no-cache \
     python3 py3-pip py3-setuptools python3-dev build-base \
     rust cargo libffi-dev openssl-dev libsodium-dev \
-    && pip3 install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
+    && python3 -m pip install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
 
 COPY run.sh /run.sh
 COPY app /app

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "1.0.1"
+version: "1.0.2"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- ensure pip installations use break-system-packages
- bump addon version to 1.0.2

## Testing
- `python -m py_compile custom_components/vserver_ssh_stats/*.py`
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b8f707e48327865008325fc0b4bb