### PR TITLE
feat: support full configuration in HACS

### DIFF
--- a/custom_components/vserver_ssh_stats/__init__.py
+++ b/custom_components/vserver_ssh_stats/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
+import json
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
@@ -100,6 +102,20 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up VServer SSH Stats from a config entry."""
     _LOGGER.debug("Setting up VServer SSH Stats entry")
+    data = entry.data
+    hass.data.setdefault(DOMAIN, {})
+    try:
+        servers = json.loads(data.get("servers_json", "[]"))
+    except ValueError:  # pragma: no cover - validation handled in flow
+        servers = []
+    hass.data[DOMAIN][entry.entry_id] = {
+        "mqtt_host": data.get("mqtt_host"),
+        "mqtt_port": data.get("mqtt_port"),
+        "mqtt_user": data.get("mqtt_user"),
+        "mqtt_pass": data.get("mqtt_pass"),
+        "interval": data.get("interval"),
+        "servers": servers,
+    }
     return True
 
 

--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -2,20 +2,28 @@
 from __future__ import annotations
 
 from typing import Any
+import json
 
 import voluptuous as vol
 from homeassistant import config_entries
 
 from . import DOMAIN
 
-DEFAULT_INTERVAL = 60
+DEFAULT_INTERVAL = 30
+
+DEFAULT_SERVERS_JSON = (
+    "[{\"name\": \"vps1\", \"host\": \"203.0.113.10\", "
+    "\"username\": \"root\", \"password\": \"deinpasswort\"}]"
+)
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("host"): str,
-        vol.Required("username"): str,
-        vol.Required("authentication"): str,
+        vol.Required("mqtt_host", default="homeassistant"): str,
+        vol.Required("mqtt_port", default=1883): int,
+        vol.Optional("mqtt_user", default=""): str,
+        vol.Optional("mqtt_pass", default=""): str,
         vol.Required("interval", default=DEFAULT_INTERVAL): int,
+        vol.Optional("servers_json", default=DEFAULT_SERVERS_JSON): str,
     }
 )
 
@@ -30,9 +38,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            await self.async_set_unique_id(user_input["host"])
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=user_input["host"], data=user_input)
+            try:
+                json.loads(user_input["servers_json"])
+            except ValueError:
+                errors["servers_json"] = "invalid_json"
+            else:
+                await self.async_set_unique_id("config")
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title="VServer SSH Stats", data=user_input
+                )
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors

--- a/custom_components/vserver_ssh_stats/strings.json
+++ b/custom_components/vserver_ssh_stats/strings.json
@@ -5,12 +5,17 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "host": "Host",
-          "username": "Username",
-          "authentication": "Authentication",
-          "interval": "Interval"
+          "mqtt_host": "MQTT host",
+          "mqtt_port": "MQTT port",
+          "mqtt_user": "MQTT user",
+          "mqtt_pass": "MQTT password",
+          "interval": "Interval",
+          "servers_json": "Servers (JSON)"
         }
       }
+    },
+    "error": {
+      "invalid_json": "Invalid JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/de.json
+++ b/custom_components/vserver_ssh_stats/translations/de.json
@@ -5,12 +5,17 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "host": "Host",
-          "username": "Benutzername",
-          "authentication": "Authentifizierung",
-          "interval": "Intervall"
+          "mqtt_host": "MQTT-Host",
+          "mqtt_port": "MQTT-Port",
+          "mqtt_user": "MQTT-Benutzer",
+          "mqtt_pass": "MQTT-Passwort",
+          "interval": "Intervall",
+          "servers_json": "Server (JSON)"
         }
       }
+    },
+    "error": {
+      "invalid_json": "Ungültiges JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/en.json
+++ b/custom_components/vserver_ssh_stats/translations/en.json
@@ -5,12 +5,17 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "host": "Host",
-          "username": "Username",
-          "authentication": "Authentication",
-          "interval": "Interval"
+          "mqtt_host": "MQTT host",
+          "mqtt_port": "MQTT port",
+          "mqtt_user": "MQTT user",
+          "mqtt_pass": "MQTT password",
+          "interval": "Interval",
+          "servers_json": "Servers (JSON)"
         }
       }
+    },
+    "error": {
+      "invalid_json": "Invalid JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/es.json
+++ b/custom_components/vserver_ssh_stats/translations/es.json
@@ -5,12 +5,17 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "host": "Host",
-          "username": "Usuario",
-          "authentication": "Autenticación",
-          "interval": "Intervalo"
+          "mqtt_host": "Host MQTT",
+          "mqtt_port": "Puerto MQTT",
+          "mqtt_user": "Usuario MQTT",
+          "mqtt_pass": "Contraseña MQTT",
+          "interval": "Intervalo",
+          "servers_json": "Servidores (JSON)"
         }
       }
+    },
+    "error": {
+      "invalid_json": "JSON no válido"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/fr.json
+++ b/custom_components/vserver_ssh_stats/translations/fr.json
@@ -5,12 +5,17 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "host": "Hôte",
-          "username": "Utilisateur",
-          "authentication": "Authentification",
-          "interval": "Intervalle"
+          "mqtt_host": "Hôte MQTT",
+          "mqtt_port": "Port MQTT",
+          "mqtt_user": "Utilisateur MQTT",
+          "mqtt_pass": "Mot de passe MQTT",
+          "interval": "Intervalle",
+          "servers_json": "Serveurs (JSON)"
         }
       }
+    },
+    "error": {
+      "invalid_json": "JSON invalide"
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow configuring MQTT and servers when installing via HACS
- align HACS defaults with addon (interval 30s, homeassistant host, sample server)
- store MQTT password in config entry

## Testing
- `python3 -m py_compile custom_components/vserver_ssh_stats/config_flow.py custom_components/vserver_ssh_stats/__init__.py`
- `pytest` *(fails: command not found; network blocked when attempting install)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c24a99d88327ba80015d0e679084