### PR TITLE
feat: add web terminal and command service

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -7,6 +7,7 @@ Das Add-on verbindet sich per **SSH** (über IP-Adresse, Benutzername und Passwo
 Die Metriken werden anschließend über **MQTT Discovery** an Home Assistant veröffentlicht, sodass sie als native Sensoren erscheinen.
 
 Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurchsatz- und Temperaturinformationen in Echtzeit von all Ihren Servern in Home Assistant Dashboards anzuzeigen.
+Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur Verfügung, und es gibt einen Home-Assistant-Service zum Ausführen beliebiger Befehle auf den Servern.
 
 ---
 
@@ -15,6 +16,8 @@ Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurch
 - Unterstützt mehrere Server mit individueller Konfiguration.
 - Konfiguration über die Home Assistant Oberfläche (Config Flow).
 - Unterstützt Passwort- und SSH-Schlüssel-Authentifizierung.
+- Interaktives Terminal über die Add-on-Weboberfläche.
+- Home-Assistant-Service zum Ausführen von Befehlen.
 - Sammelt:
   - CPU-Auslastung (%)
   - Speicherauslastung (%)
@@ -40,6 +43,12 @@ Wenn du Statistiken ohne MQTT sammeln möchtest, führe `app/simple_collector.py
 Optional kannst du deine Home Assistant Basis-URL und ein Long-Lived Access Token angeben. Wenn vorhanden, erstellt das Skript über die Home Assistant REST API Sensoren wie `sensor.<name>_cpu`, `sensor.<name>_mem` usw., damit die Werte ohne MQTT in der Oberfläche erscheinen.
 
 Der Haupt-Collector (`app/collector.py`) unterstützt ebenfalls einen leichtgewichtigen Modus ohne MQTT: Führe ihn einfach ohne die Umgebungsvariable `MQTT_HOST` aus. In diesem Fall werden die gesammelten Statistiken in der Konsole protokolliert, anstatt an einen Broker gesendet zu werden.
+
+### Web-Terminal und Befehlsservice
+
+Das Add-on stellt unter `http://<addon-ip>:8099/terminal.html` ein einfaches SSH-Terminal im Browser bereit. Gib Host, Benutzername und Passwort ein, um eine interaktive Shell-Sitzung zu starten. Die Zugangsdaten werden direkt an das Add-on übermittelt und nicht an externe Dienste weitergeleitet.
+
+Für Automatisierungsszenarien registriert die Home-Assistant-Integration den Service `vserver_ssh_stats.run_command`. Damit lässt sich ein beliebiger Befehl auf einem Server ausführen; die Ausgabe wird als Ereignis `vserver_ssh_stats_command` im Event-Bus veröffentlicht.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 [Deutsch](README.de.md) | [Español](README.es.md) | [Français](README.fr.md)
 
 ## Overview
-The **VServer SSH Stats** add-on for Home Assistant allows you to monitor remote Linux servers (vServers, Raspberry Pi, or dedicated machines) without installing any additional agents on the target machines.  
+The **VServer SSH Stats** add-on for Home Assistant allows you to monitor remote Linux servers (vServers, Raspberry Pi, or dedicated machines) without installing any additional agents on the target machines.
 
 The add-on connects via **SSH** (using IP address, username, and password or SSH key) and collects system metrics directly from `/proc`, `df`, and other standard Linux interfaces.  
 The metrics are then published to Home Assistant via **MQTT Discovery**, so they appear as native sensors.
 
 This makes it possible to get real-time CPU, memory, disk, uptime, network throughput, and temperature information from all your servers inside Home Assistant dashboards.
+
+In addition to statistics collection, the add-on now includes an **interactive web-based terminal** and a Home Assistant service to run ad-hoc commands on your servers.
 
 ---
 
@@ -17,6 +19,8 @@ This makes it possible to get real-time CPU, memory, disk, uptime, network throu
 - Supports multiple servers with individual configuration.
 - Configurable via Home Assistant UI (config flow).
 - Supports password and SSH key authentication.
+- Interactive terminal accessible via the add-on web UI.
+- Home Assistant service to execute arbitrary commands remotely.
 - Collects:
   - CPU usage (%)
   - Memory usage (%)
@@ -43,6 +47,12 @@ If you want to gather stats without using MQTT, run `app/simple_collector.py`. T
 Optionally you can enter your Home Assistant base URL and a long-lived access token. When provided, the script will create sensors like `sensor.<name>_cpu`, `sensor.<name>_mem`, etc., via the Home Assistant REST API for each server so the values show up in the UI without MQTT.
 
 The main collector (`app/collector.py`) also supports a lightweight mode without MQTT: simply run it without the `MQTT_HOST` environment variable. In that case the collected statistics are logged to the console instead of being published to a broker.
+
+### Web Terminal and Command Service
+
+The add-on exposes a simple web-based SSH terminal at `http://<addon-ip>:8099/terminal.html`. Enter the host, username and password to start an interactive shell session in your browser. The credentials are sent directly to the add-on and never routed through external services.
+
+For automation use cases, the Home Assistant integration registers a `vserver_ssh_stats.run_command` service. Provide the host, username, command and optional credentials to execute a single command on a server. The command output is fired as an event named `vserver_ssh_stats_command`.
 
 
 ---

--- a/custom_components/vserver_ssh_stats/services.yaml
+++ b/custom_components/vserver_ssh_stats/services.yaml
@@ -9,3 +9,26 @@ get_uptime:
 list_connections:
   name: List SSH connections
   description: List IP addresses of active SSH sessions.
+
+run_command:
+  name: Run SSH command
+  description: Execute an arbitrary command on a remote server.
+  fields:
+    host:
+      description: Hostname or IP of the server.
+      example: 192.168.1.10
+    username:
+      description: SSH username.
+      example: root
+    command:
+      description: Command to execute.
+      example: uptime
+    password:
+      description: Password for authentication.
+      example: secret
+    key:
+      description: Path to SSH private key.
+      example: /config/ssh/id_rsa
+    port:
+      description: SSH port.
+      example: 22

--- a/vserver_ssh_stats/Dockerfile
+++ b/vserver_ssh_stats/Dockerfile
@@ -4,7 +4,8 @@ FROM ${BUILD_FROM}
 RUN apk add --no-cache \
     python3 py3-pip py3-setuptools python3-dev build-base \
     rust cargo libffi-dev openssl-dev libsodium-dev \
-    && python3 -m pip install --no-cache-dir --break-system-packages wheel paramiko paho-mqtt
+    && python3 -m pip install --no-cache-dir --break-system-packages \
+        wheel paramiko paho-mqtt asyncssh websockets
 
 COPY run.sh /run.sh
 COPY app /app

--- a/vserver_ssh_stats/app/terminal.py
+++ b/vserver_ssh_stats/app/terminal.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+
+import asyncssh
+import websockets
+
+
+async def _bridge(websocket: websockets.WebSocketServerProtocol):
+    """Bridge between a websocket and an SSH session.
+
+    The first message from the client must be a JSON object containing
+    `host`, `user`, optional `password`, and optional `port` (default 22).
+    """
+
+    try:
+        params_raw = await websocket.recv()
+        params = json.loads(params_raw)
+    except Exception:
+        await websocket.send("Invalid handshake data\n")
+        await websocket.close()
+        return
+
+    host = params.get("host")
+    user = params.get("user")
+    password = params.get("password")
+    port = int(params.get("port", 22))
+
+    if not host or not user:
+        await websocket.send("Missing host or user parameters\n")
+        await websocket.close()
+        return
+
+    try:
+        async with asyncssh.connect(
+            host,
+            username=user,
+            password=password or None,
+            known_hosts=None,
+            port=port,
+        ) as conn:
+            async with conn.create_process(term_type="xterm") as process:
+                async def ws_to_ssh():
+                    async for message in websocket:
+                        process.stdin.write(message)
+
+                async def ssh_to_ws():
+                    async for data in process.stdout:
+                        await websocket.send(data)
+
+                await asyncio.gather(ws_to_ssh(), ssh_to_ws())
+    except Exception as exc:  # pragma: no cover - network errors
+        await websocket.send(f"Connection failed: {exc}\n")
+
+
+async def main() -> None:
+    """Run the websocket SSH bridge."""
+    async with websockets.serve(_bridge, "0.0.0.0", 8098):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/vserver_ssh_stats/app/web/index.html
+++ b/vserver_ssh_stats/app/web/index.html
@@ -20,6 +20,7 @@
   <div id="navbar">
     <a id="nav-stats" href="#" onclick="showTab('stats')">Server Stats</a>
     <a id="nav-docker" href="#" onclick="showTab('docker')">Docker Container</a>
+    <a href="terminal.html">Terminal</a>
   </div>
   <div id="main">
     <h1>VServer SSH Stats</h1>

--- a/vserver_ssh_stats/app/web/terminal.html
+++ b/vserver_ssh_stats/app/web/terminal.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>SSH Terminal</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
+<script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
+<style>
+#terminal { width: 100%; height: 80vh; }
+</style>
+</head>
+<body>
+<label>Host: <input id="host" /></label>
+<label>User: <input id="user" /></label>
+<label>Password: <input id="password" type="password" /></label>
+<label>Port: <input id="port" value="22" /></label>
+<button id="connect">Connect</button>
+<div id="terminal"></div>
+<script>
+const term = new Terminal();
+term.open(document.getElementById('terminal'));
+let ws;
+
+document.getElementById('connect').onclick = () => {
+  const host = document.getElementById('host').value;
+  const user = document.getElementById('user').value;
+  const password = document.getElementById('password').value;
+  const port = parseInt(document.getElementById('port').value, 10) || 22;
+  ws = new WebSocket(`ws://${window.location.hostname}:8098/`);
+  ws.onopen = () => {
+    ws.send(JSON.stringify({ host, user, password, port }));
+    term.onData(data => ws && ws.send(data));
+  };
+  ws.onmessage = (ev) => term.write(ev.data);
+  ws.onclose = () => { term.write('\r\nConnection closed\r\n'); ws = null; };
+};
+</script>
+</body>
+</html>

--- a/vserver_ssh_stats/run.sh
+++ b/vserver_ssh_stats/run.sh
@@ -14,4 +14,7 @@ export DISABLED_JSON=$(jq -c '.disabled_entities // []' ${CONFIG_PATH})
 # Start lightweight web server for optional sidebar access
 python3 -m http.server 8099 --directory /app/web &
 
+# Start websocket SSH terminal bridge
+python3 /app/terminal.py &
+
 exec python3 /app/collector.py


### PR DESCRIPTION
## Summary
- add websocket-based SSH terminal and expose from add-on web UI
- add `run_command` service for executing ad-hoc SSH commands
- document new terminal features and install deps
- secure terminal handshake so credentials are sent in-session, not via URL

## Testing
- `python -m py_compile vserver_ssh_stats/app/terminal.py custom_components/vserver_ssh_stats/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d6ef24c4832793e06c383c5a00ba