### PR TITLE
chore: add automatic version bump workflow

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,29 @@
+name: Auto Version Bump
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Bump version
+        run: |
+          python scripts/bump_version.py
+          if git diff --quiet; then
+            echo "Version unchanged"
+          else
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git commit -am 'chore: bump version'
+            git push
+          fi

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/404GamerNotFound/vserver-ssh-stats/issues",
   "requirements": [],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+
+MANIFEST_PATH = Path("custom_components/vserver_ssh_stats/manifest.json")
+CONFIG_PATH = Path("vserver_ssh_stats/config.yaml")
+
+def bump_version(version: str) -> str:
+    major, minor, patch = map(int, version.split("."))
+    patch += 1
+    return f"{major}.{minor}.{patch}"
+
+def update_manifest(new_version: str):
+    data = json.loads(MANIFEST_PATH.read_text())
+    data["version"] = new_version
+    MANIFEST_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+def update_config(new_version: str):
+    text = CONFIG_PATH.read_text()
+    text = re.sub(r'version:\s*"\d+\.\d+\.\d+"', f'version: "{new_version}"', text)
+    CONFIG_PATH.write_text(text)
+
+def main():
+    data = json.loads(MANIFEST_PATH.read_text())
+    current_version = data.get("version", "0.0.0")
+    new_version = bump_version(current_version)
+    update_manifest(new_version)
+    update_config(new_version)
+    print(new_version)
+
+if __name__ == "__main__":
+    main()

--- a/vserver_ssh_stats/config.yaml
+++ b/vserver_ssh_stats/config.yaml
@@ -1,5 +1,5 @@
 name: VServer SSH Stats
-version: "1.0.3"
+version: "1.0.4"
 slug: vserver_ssh_stats
 description: Holt CPU, RAM, Disk, Net per SSH (ohne Agent) und veröffentlicht sie via MQTT.
 startup: services


### PR DESCRIPTION
## Summary
- add script to bump manifest and add-on version numbers
- run GitHub workflow on pushes to main to commit bumped version

## Testing
- `pytest` *(fails: command not found, unable to install due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e58208608327959a52759c347444