### PR TITLE
feat: add one-click server buttons

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -46,7 +46,7 @@ Der Haupt-Collector (`app/collector.py`) unterstützt ebenfalls einen leichtgewi
 
 ### Web-Terminal und Befehlsservice
 
-Das Add-on stellt unter `http://<addon-ip>:8099/terminal.html` ein einfaches SSH-Terminal im Browser bereit. Gib Host, Benutzername und Passwort ein, um eine interaktive Shell-Sitzung zu starten. Die Zugangsdaten werden direkt an das Add-on übermittelt und nicht an externe Dienste weitergeleitet.
+Das Add-on stellt unter `http://<addon-ip>:8099/terminal.html` ein einfaches SSH-Terminal im Browser bereit. Konfigurierte Server werden als Schaltflächen für den Sofortzugriff angezeigt; alternativ kannst du Host, Benutzername und Passwort manuell eingeben, um eine interaktive Shell-Sitzung zu starten. Die Zugangsdaten werden direkt an das Add-on übermittelt und nicht an externe Dienste weitergeleitet.
 
 Für Automatisierungsszenarien registriert die Home-Assistant-Integration den Service `vserver_ssh_stats.run_command`. Damit lässt sich ein beliebiger Befehl auf einem Server ausführen; die Ausgabe wird als Ereignis `vserver_ssh_stats_command` im Event-Bus veröffentlicht.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The main collector (`app/collector.py`) also supports a lightweight mode without
 
 ### Web Terminal and Command Service
 
-The add-on exposes a simple web-based SSH terminal at `http://<addon-ip>:8099/terminal.html`. Enter the host, username and password to start an interactive shell session in your browser. The credentials are sent directly to the add-on and never routed through external services.
+The add-on exposes a simple web-based SSH terminal at `http://<addon-ip>:8099/terminal.html`. Configured servers appear as buttons for one-click access, or you can enter the host, username and password manually to start an interactive shell session in your browser. The credentials are sent directly to the add-on and never routed through external services.
 
 For automation use cases, the Home Assistant integration registers a `vserver_ssh_stats.run_command` service. Provide the host, username, command and optional credentials to execute a single command on a server. The command output is fired as an event named `vserver_ssh_stats_command`.
 

--- a/vserver_ssh_stats/app/web/terminal.html
+++ b/vserver_ssh_stats/app/web/terminal.html
@@ -5,11 +5,13 @@
 <title>SSH Terminal</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
 <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
+<script src="servers.js"></script>
 <style>
 #terminal { width: 100%; height: 80vh; }
 </style>
 </head>
 <body>
+<div id="server-buttons"></div>
 <label>Host: <input id="host" /></label>
 <label>User: <input id="user" /></label>
 <label>Password: <input id="password" type="password" /></label>
@@ -21,19 +23,40 @@ const term = new Terminal();
 term.open(document.getElementById('terminal'));
 let ws;
 
-document.getElementById('connect').onclick = () => {
-  const host = document.getElementById('host').value;
-  const user = document.getElementById('user').value;
-  const password = document.getElementById('password').value;
-  const port = parseInt(document.getElementById('port').value, 10) || 22;
+function connect({ host, user, password, port }) {
   ws = new WebSocket(`ws://${window.location.hostname}:8098/`);
   ws.onopen = () => {
     ws.send(JSON.stringify({ host, user, password, port }));
-    term.onData(data => ws && ws.send(data));
   };
   ws.onmessage = (ev) => term.write(ev.data);
   ws.onclose = () => { term.write('\r\nConnection closed\r\n'); ws = null; };
+}
+
+term.onData(data => ws && ws.send(data));
+
+document.getElementById('connect').onclick = () => {
+  connect({
+    host: document.getElementById('host').value,
+    user: document.getElementById('user').value,
+    password: document.getElementById('password').value,
+    port: parseInt(document.getElementById('port').value, 10) || 22,
+  });
 };
+
+if (window.SERVER_LIST && Array.isArray(window.SERVER_LIST)) {
+  const container = document.getElementById('server-buttons');
+  window.SERVER_LIST.forEach((srv) => {
+    const btn = document.createElement('button');
+    btn.textContent = srv.name || srv.host;
+    btn.onclick = () => connect({
+      host: srv.host,
+      user: srv.username,
+      password: srv.password || '',
+      port: srv.port || 22,
+    });
+    container.appendChild(btn);
+  });
+}
 </script>
 </body>
 </html>

--- a/vserver_ssh_stats/run.sh
+++ b/vserver_ssh_stats/run.sh
@@ -11,6 +11,9 @@ export INTERVAL=$(jq -r .interval_seconds ${CONFIG_PATH})
 export SERVERS_JSON=$(jq -c .servers ${CONFIG_PATH})
 export DISABLED_JSON=$(jq -c '.disabled_entities // []' ${CONFIG_PATH})
 
+# Expose configured servers to the web UI
+printf 'window.SERVER_LIST = %s;\n' "$SERVERS_JSON" > /app/web/servers.js
+
 # Start lightweight web server for optional sidebar access
 python3 -m http.server 8099 --directory /app/web &
 


### PR DESCRIPTION
## Summary
- expose configured servers to terminal web UI
- add one-click connect buttons for servers
- document web terminal one-click access

## Testing
- `bash -n vserver_ssh_stats/run.sh`
- `python -m py_compile vserver_ssh_stats/app/terminal.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7e89bb4bc83279b56ee01c6ee39bf