### PR TITLE
fix: support secure websocket

### DIFF
--- a/vserver_ssh_stats/app/web/terminal.html
+++ b/vserver_ssh_stats/app/web/terminal.html
@@ -24,7 +24,8 @@ term.open(document.getElementById('terminal'));
 let ws;
 
 function connect({ host, user, password, port }) {
-  ws = new WebSocket(`ws://${window.location.hostname}:8098/`);
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${protocol}://${window.location.hostname}:8098/`);
   ws.onopen = () => {
     ws.send(JSON.stringify({ host, user, password, port }));
   };


### PR DESCRIPTION
## Summary
- switch the terminal websocket to wss when running over https

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6389ac88327b9106ff5f9d4e5ba