### PR TITLE
fix: support secure websocket

### DIFF
--- a/vserver_ssh_stats/app/web/terminal.html
+++ b/vserver_ssh_stats/app/web/terminal.html
@@ -24,7 +24,11 @@ term.open(document.getElementById('terminal'));
 let ws;
 
 function connect({ host, user, password, port }) {
-  ws = new WebSocket(`ws://${window.location.hostname}:8098/`);
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const hostname = window.location.hostname.includes(':')
+    ? `[${window.location.hostname}]`
+    : window.location.hostname;
+  ws = new WebSocket(`${protocol}://${hostname}:8098/`);
   ws.onopen = () => {
     ws.send(JSON.stringify({ host, user, password, port }));
   };


### PR DESCRIPTION
## Summary
- switch the terminal websocket to wss when running over https
- handle IPv6 hostnames when constructing websocket URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6389ac88327b9106ff5f9d4e5ba