### PR TITLE
feat: separate server fields in config

### DIFF
--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -11,15 +11,13 @@ from . import DOMAIN
 
 DEFAULT_INTERVAL = 30
 
-DEFAULT_SERVERS_JSON = (
-    "[{\"name\": \"vps1\", \"host\": \"203.0.113.10\", "
-    "\"username\": \"root\", \"password\": \"deinpasswort\"}]"
-)
-
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required("interval", default=DEFAULT_INTERVAL): int,
-        vol.Required("servers_json", default=DEFAULT_SERVERS_JSON): str,
+        vol.Required("name"): str,
+        vol.Required("host"): str,
+        vol.Required("username"): str,
+        vol.Required("password"): str,
     }
 )
 
@@ -31,20 +29,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
-        errors: dict[str, str] = {}
-
         if user_input is not None:
-            try:
-                json.loads(user_input["servers_json"])
-            except ValueError:
-                errors["servers_json"] = "invalid_json"
-            else:
-                await self.async_set_unique_id("config")
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title="VServer SSH Stats", data=user_input
-                )
+            server = {
+                "name": user_input["name"],
+                "host": user_input["host"],
+                "username": user_input["username"],
+                "password": user_input["password"],
+            }
+            data = {
+                "interval": user_input["interval"],
+                "servers_json": json.dumps([server]),
+            }
+            await self.async_set_unique_id("config")
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title="VServer SSH Stats", data=data)
 
-        return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/custom_components/vserver_ssh_stats/strings.json
+++ b/custom_components/vserver_ssh_stats/strings.json
@@ -6,12 +6,12 @@
         "title": "VServer SSH Stats",
         "data": {
           "interval": "Interval",
-          "servers_json": "Servers (JSON)"
+          "name": "Name",
+          "host": "Host",
+          "username": "Username",
+          "password": "Password"
         }
       }
-    },
-    "error": {
-      "invalid_json": "Invalid JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/de.json
+++ b/custom_components/vserver_ssh_stats/translations/de.json
@@ -6,12 +6,12 @@
         "title": "VServer SSH Stats",
         "data": {
           "interval": "Intervall",
-          "servers_json": "Server (JSON)"
+          "name": "Name",
+          "host": "Host",
+          "username": "Benutzername",
+          "password": "Passwort"
         }
       }
-    },
-    "error": {
-      "invalid_json": "Ungültiges JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/en.json
+++ b/custom_components/vserver_ssh_stats/translations/en.json
@@ -6,12 +6,12 @@
         "title": "VServer SSH Stats",
         "data": {
           "interval": "Interval",
-          "servers_json": "Servers (JSON)"
+          "name": "Name",
+          "host": "Host",
+          "username": "Username",
+          "password": "Password"
         }
       }
-    },
-    "error": {
-      "invalid_json": "Invalid JSON"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/es.json
+++ b/custom_components/vserver_ssh_stats/translations/es.json
@@ -6,12 +6,12 @@
         "title": "VServer SSH Stats",
         "data": {
           "interval": "Intervalo",
-          "servers_json": "Servidores (JSON)"
+          "name": "Nombre",
+          "host": "Host",
+          "username": "Usuario",
+          "password": "Contraseña"
         }
       }
-    },
-    "error": {
-      "invalid_json": "JSON no válido"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/fr.json
+++ b/custom_components/vserver_ssh_stats/translations/fr.json
@@ -6,12 +6,12 @@
         "title": "VServer SSH Stats",
         "data": {
           "interval": "Intervalle",
-          "servers_json": "Serveurs (JSON)"
+          "name": "Nom",
+          "host": "Hôte",
+          "username": "Nom d'utilisateur",
+          "password": "Mot de passe"
         }
       }
-    },
-    "error": {
-      "invalid_json": "JSON invalide"
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace JSON server input with dedicated name, host, username, and password fields
- update translations for the new configuration fields

## Testing
- `python -m py_compile custom_components/vserver_ssh_stats/config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b990dea4b08327a0ec757334b15d6b