### PR TITLE
Allow configuring multiple VServer SSH Stats servers

### DIFF
--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -50,8 +50,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "interval": user_input["interval"],
                 "servers_json": json.dumps([server]),
             }
-            await self.async_set_unique_id("config")
+            await self.async_set_unique_id(server["host"])  # Prevent duplicate hosts
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(title="VServer SSH Stats", data=data)
+            return self.async_create_entry(title=server["name"], data=data)
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/custom_components/vserver_ssh_stats/sensor.py
+++ b/custom_components/vserver_ssh_stats/sensor.py
@@ -107,10 +107,11 @@ class VServerSensor(CoordinatorEntity[VServerCoordinator], SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{server_name}_{description.key}"
+        host = coordinator.server["host"]
+        self._attr_unique_id = f"{host}_{description.key}"
         self._attr_name = f"{server_name} {description.name}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, server_name)},
+            identifiers={(DOMAIN, host)},
             name=server_name,
         )
 


### PR DESCRIPTION
## Summary
- allow multiple VServer SSH Stats instances by using host as unique ID
- ensure sensor and device identifiers use host for uniqueness

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9991e00348327a6f5243a28b0c730