### PR TITLE
Add remote update and reboot services

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -19,7 +19,7 @@ Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur
 - Konfiguration über die Home Assistant Oberfläche (Config Flow).
 - Unterstützt Passwort- und SSH-Schlüssel-Authentifizierung.
 - Interaktives Terminal über die Add-on-Weboberfläche.
-- Home-Assistant-Service zum Ausführen von Befehlen.
+- Home-Assistant-Services zum Ausführen von Befehlen, Paket-Updates und Reboots.
 - Sammelt:
   - CPU-Auslastung (%)
   - Speicherauslastung (%)
@@ -50,7 +50,7 @@ Der Haupt-Collector (`app/collector.py`) unterstützt ebenfalls einen leichtgewi
 
 Das Add-on stellt unter `http://<addon-ip>:8099/terminal.html` ein einfaches SSH-Terminal im Browser bereit. Konfigurierte Server werden als Schaltflächen für den Sofortzugriff angezeigt; alternativ kannst du Host, Benutzername und Passwort manuell eingeben, um eine interaktive Shell-Sitzung zu starten. Die Zugangsdaten werden direkt an das Add-on übermittelt und nicht an externe Dienste weitergeleitet.
 
-Für Automatisierungsszenarien registriert die Home-Assistant-Integration den Service `vserver_ssh_stats.run_command`. Damit lässt sich ein beliebiger Befehl auf einem Server ausführen; die Ausgabe wird als Ereignis `vserver_ssh_stats_command` im Event-Bus veröffentlicht.
+Für Automatisierungsszenarien registriert die Home-Assistant-Integration mehrere Dienste: `vserver_ssh_stats.run_command`, `vserver_ssh_stats.update_packages` und `vserver_ssh_stats.reboot_host`. Jeder Dienst veröffentlicht seine Ausgabe als Ereignis im Event-Bus.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In addition to statistics collection, the add-on now includes an **interactive w
 - Automatic **MQTT Discovery** for easy integration with Home Assistant.
 - Configurable update interval (default: 30 seconds).
 - Optional lightweight web interface that can be shown in the Home Assistant sidebar, now with a Docker container tab.
-- Services to fetch the server's local IP, uptime, and list active SSH connections.
+- Services to fetch the server's local IP, uptime, list active SSH connections, run commands, update packages, and reboot the host.
 
 ### Standalone Usage Without MQTT
 
@@ -54,7 +54,7 @@ The main collector (`app/collector.py`) also supports a lightweight mode without
 
 The add-on exposes a simple web-based SSH terminal at `http://<addon-ip>:8099/terminal.html`. Configured servers appear as buttons for one-click access, or you can enter the host, username and password manually to start an interactive shell session in your browser. The credentials are sent directly to the add-on and never routed through external services.
 
-For automation use cases, the Home Assistant integration registers a `vserver_ssh_stats.run_command` service. Provide the host, username, command and optional credentials to execute a single command on a server. The command output is fired as an event named `vserver_ssh_stats_command`.
+For automation use cases, the Home Assistant integration registers several services: `vserver_ssh_stats.run_command`, `vserver_ssh_stats.update_packages`, and `vserver_ssh_stats.reboot_host`. Each service publishes its output as an event on the Home Assistant bus.
 
 
 ---

--- a/custom_components/vserver_ssh_stats/services.yaml
+++ b/custom_components/vserver_ssh_stats/services.yaml
@@ -32,3 +32,43 @@ run_command:
     port:
       description: SSH port.
       example: 22
+
+update_packages:
+  name: Update packages
+  description: Update system packages using apt, dnf, or yum.
+  fields:
+    host:
+      description: Hostname or IP of the server.
+      example: 192.168.1.10
+    username:
+      description: SSH username.
+      example: root
+    password:
+      description: Password for authentication.
+      example: secret
+    key:
+      description: Path to SSH private key.
+      example: /config/ssh/id_rsa
+    port:
+      description: SSH port.
+      example: 22
+
+reboot_host:
+  name: Reboot host
+  description: Reboot the remote server.
+  fields:
+    host:
+      description: Hostname or IP of the server.
+      example: 192.168.1.10
+    username:
+      description: SSH username.
+      example: root
+    password:
+      description: Password for authentication.
+      example: secret
+    key:
+      description: Path to SSH private key.
+      example: /config/ssh/id_rsa
+    port:
+      description: SSH port.
+      example: 22


### PR DESCRIPTION
## Summary
- add `update_packages` service to run distro package upgrades over SSH
- add `reboot_host` service for remote restarts
- document new services in README files

## Testing
- `python -m pytest`
- `python -m pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile custom_components/vserver_ssh_stats/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7edc0348327b0b1db87befb1130