### PR TITLE
Add service status sensors

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -36,6 +36,9 @@ Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur
   - Betriebssystem-Version
   - Installierte Pakete (Anzahl und Liste)
   - Docker-Installation, laufende Container und Auslastung einzelner Container (CPU und Speicher)
+  - VNC-Unterstützung
+  - HTTP/HTTPS-Webserver-Status
+  - SSH aktiviert
 - Automatische **MQTT Discovery** für einfache Integration in Home Assistant.
 - Konfigurierbares Aktualisierungsintervall (Standard: 30 Sekunden).
 - Optionale leichtgewichtige Weboberfläche, die in der Home-Assistant-Seitenleiste angezeigt werden kann, jetzt mit einem Reiter für Docker-Container.
@@ -162,6 +165,9 @@ Für jeden Server sind folgende Entitäten verfügbar:
 - `sensor.<name>_pkg_list` – Verfügbare Updates (erste 10)
 - `sensor.<name>_docker` – 1, wenn Docker installiert ist, sonst 0
 - `sensor.<name>_containers` – Laufende Docker-Container (kommagetrennte Liste)
+- `sensor.<name>_vnc` – "ja", wenn ein VNC-Server erkannt wurde
+- `sensor.<name>_web` – "ja", wenn ein HTTP- oder HTTPS-Dienst lauscht
+- `sensor.<name>_ssh` – "ja", wenn der SSH-Dienst lauscht
 - Für jeden laufenden Container: `sensor.<name>_container_<container>_cpu` (CPU-Auslastung %) und `sensor.<name>_container_<container>_mem` (Speicherauslastung %)
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ In addition to statistics collection, the add-on now includes an **interactive w
   - Operating system version
   - Installed packages (count and list)
   - Docker installation, running containers, and per-container CPU/memory usage
+  - VNC support status
+  - HTTP/HTTPS web server status
+  - SSH enabled status
 - Automatic **MQTT Discovery** for easy integration with Home Assistant.
 - Configurable update interval (default: 30 seconds).
 - Optional lightweight web interface that can be shown in the Home Assistant sidebar, now with a Docker container tab.
@@ -168,6 +171,9 @@ For each server, the following entities will be available:
 - `sensor.<name>_pkg_list` – Pending update packages (first 10)
 - `sensor.<name>_docker` – 1 if Docker is installed, 0 otherwise
 - `sensor.<name>_containers` – Running Docker containers (comma-separated list)
+- `sensor.<name>_vnc` – "yes" if a VNC server is detected
+- `sensor.<name>_web` – "yes" if an HTTP or HTTPS service is listening
+- `sensor.<name>_ssh` – "yes" if the SSH service is listening
 - For each running container: `sensor.<name>_container_<container>_cpu` (CPU usage %) and `sensor.<name>_container_<container>_mem` (memory usage %)
 
 ---

--- a/addon/vserver_ssh_stats/app/collector.py
+++ b/addon/vserver_ssh_stats/app/collector.py
@@ -120,6 +120,9 @@ def ensure_discovery(name: str) -> None:
         ("pkg_list", None, None, True),
         ("docker", None, None, False),
         ("containers", None, None, True),
+        ("vnc", None, None, True),
+        ("web", None, None, True),
+        ("ssh", None, None, True),
     ]:
         if key in DISABLED_ENTITIES:
             continue
@@ -219,6 +222,9 @@ def sample_server(srv: Dict[str, Any]) -> Dict[str, Any]:
         "pkg_list": data.get("pkg_list", ""),
         "docker": int(data.get("docker", 0)),
         "containers": data.get("containers", ""),
+        "vnc": data.get("vnc", ""),
+        "web": data.get("web", ""),
+        "ssh": data.get("ssh", ""),
         "container_stats": data.get("container_stats", []),
     }
 
@@ -296,6 +302,9 @@ def main():
                     "pkg_list": "",
                     "docker": 0,
                     "containers": "",
+                    "vnc": "",
+                    "web": "",
+                    "ssh": "",
                     "container_stats": [],
                 }
                 err_payload = err.copy()

--- a/addon/vserver_ssh_stats/app/simple_collector.py
+++ b/addon/vserver_ssh_stats/app/simple_collector.py
@@ -71,6 +71,9 @@ def sample(host: str, username: str, password: Optional[str], key: Optional[str]
         "pkg_list": data.get("pkg_list", ""),
         "docker": int(data.get("docker", 0)),
         "containers": data.get("containers", ""),
+        "vnc": data.get("vnc", ""),
+        "web": data.get("web", ""),
+        "ssh": data.get("ssh", ""),
         "container_stats": cont_stats,
     }
     for c in cont_stats:

--- a/custom_components/vserver_ssh_stats/sensor.py
+++ b/custom_components/vserver_ssh_stats/sensor.py
@@ -73,6 +73,9 @@ SENSORS: tuple[VServerSensorDescription, ...] = (
     VServerSensorDescription(key="pkg_list", name="Package List"),
     VServerSensorDescription(key="docker", name="Docker Containers"),
     VServerSensorDescription(key="containers", name="Containers"),
+    VServerSensorDescription(key="vnc", name="VNC Supported"),
+    VServerSensorDescription(key="web", name="Web Server"),
+    VServerSensorDescription(key="ssh", name="SSH Enabled"),
 )
 
 

--- a/custom_components/vserver_ssh_stats/ssh_collector.py
+++ b/custom_components/vserver_ssh_stats/ssh_collector.py
@@ -69,6 +69,9 @@ async def async_sample(host: str, username: str, password: Optional[str], key: O
         "load_5": data.get("load_5"),
         "load_15": data.get("load_15"),
         "cpu_freq": data.get("cpu_freq"),
+        "vnc": data.get("vnc", ""),
+        "web": data.get("web", ""),
+        "ssh": data.get("ssh", ""),
         "container_stats": cont_stats,
     }
     for c in cont_stats:


### PR DESCRIPTION
## Summary
- detect SSH, HTTP/HTTPS and VNC services via remote script
- expose new service status metrics in integration and add-on
- document new sensors in English and German README

## Testing
- `python -m py_compile addon/vserver_ssh_stats/app/collector.py addon/vserver_ssh_stats/app/remote_script.py addon/vserver_ssh_stats/app/simple_collector.py custom_components/vserver_ssh_stats/remote_script.py custom_components/vserver_ssh_stats/sensor.py custom_components/vserver_ssh_stats/ssh_collector.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba678e06b48327b66ee3010a348ac2