### PR TITLE
docs: update translated readmes

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -11,7 +11,7 @@ Die Metriken werden anschließend über **MQTT Discovery** an Home Assistant ver
 Alternativ kann die HACS-Integration die Server direkt per SSH abfragen und die Sensoren ohne MQTT oder Add-on erstellen.
 
 Dadurch ist es möglich, CPU-, Speicher-, Festplatten-, Laufzeit-, Netzwerkdurchsatz- und Temperaturinformationen in Echtzeit von all Ihren Servern in Home Assistant Dashboards anzuzeigen.
-Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur Verfügung, und es gibt einen Home-Assistant-Service zum Ausführen beliebiger Befehle auf den Servern.
+Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur Verfügung, und es gibt einen Home-Assistant-Service zum Ausführen beliebiger Befehle auf den Servern sowie Dienste zum Abrufen der lokalen IP, der Uptime und aktiver SSH-Verbindungen.
 
 ---
 
@@ -42,6 +42,7 @@ Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur
 - Automatische **MQTT Discovery** für einfache Integration in Home Assistant.
 - Konfigurierbares Aktualisierungsintervall (Standard: 30 Sekunden).
 - Optionale leichtgewichtige Weboberfläche, die in der Home-Assistant-Seitenleiste angezeigt werden kann, jetzt mit einem Reiter für Docker-Container.
+- Dienste zum Abrufen der lokalen IP-Adresse, der Uptime, Liste aktiver SSH-Verbindungen, zum Ausführen von Befehlen, Aktualisieren von Paketen und Neustarten des Hosts.
 
 ### Standalone-Nutzung ohne MQTT
 

--- a/README.es.md
+++ b/README.es.md
@@ -12,6 +12,8 @@ Alternativamente, la integración de HACS puede consultar tus servidores directa
 
 Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiempo de actividad, rendimiento de red y temperatura de todos tus servidores en los paneles de Home Assistant.
 
+Además de la recopilación de estadísticas, el complemento incluye ahora un terminal web interactivo y un servicio de Home Assistant para ejecutar comandos ad hoc en tus servidores.
+
 ---
 
 ## Características
@@ -19,6 +21,8 @@ Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiem
 - Soporta múltiples servidores con configuración individual.
 - Configurable a través de la interfaz de Home Assistant (config flow).
 - Soporta autenticación por contraseña y por clave SSH.
+- Terminal interactivo accesible desde la interfaz web del complemento.
+- Servicios de Home Assistant y entidades de botón para ejecutar comandos remotos, actualizar paquetes y reiniciar.
 - Recopila:
   - Uso de CPU (%)
   - Uso de memoria (%)
@@ -33,9 +37,13 @@ Esto permite obtener información en tiempo real sobre CPU, memoria, disco, tiem
   - Versión del sistema operativo
   - Paquetes instalados (cantidad y lista)
   - Detección de Docker, contenedores en ejecución y uso por contenedor (CPU y memoria)
+  - Estado de soporte VNC
+  - Estado de servidor web HTTP/HTTPS
+  - Estado de servicio SSH
 - **MQTT Discovery** automática para una fácil integración con Home Assistant.
 - Intervalo de actualización configurable (por defecto: 30 segundos).
 - Interfaz web ligera opcional que puede mostrarse en la barra lateral de Home Assistant, ahora con una pestaña de contenedores Docker.
+- Servicios para obtener la IP local del servidor, el tiempo de actividad, listar conexiones SSH activas, ejecutar comandos, actualizar paquetes y reiniciar el host.
 
 ### Uso independiente sin MQTT
 
@@ -89,6 +97,9 @@ mqtt_port: 1883
 mqtt_user: mqttuser
 mqtt_pass: mqttpassword
 interval_seconds: 30
+disabled_entities:
+  - pkg_list
+  - temp
 servers:
   - name: "pi5"
     host: "192.168.1.10"
@@ -106,6 +117,7 @@ servers:
 - **mqtt_port** – Puerto del broker MQTT (predeterminado: `1883`).
 - **mqtt_user / mqtt_pass** – Credenciales MQTT.
 - **interval_seconds** – Intervalo de sondeo en segundos (mínimo 5).
+- **disabled_entities** – Lista de claves de sensores que se desactivarán (por ejemplo, `cpu`, `mem`). Todos activados por defecto.
 - **servers** – Lista de servidores a supervisar:
   - `name` – Nombre amigable (usado como prefijo de entidad).
   - `host` – Dirección IP o nombre de host del servidor.
@@ -113,6 +125,16 @@ servers:
   - `password` – Contraseña SSH (opcional si se usa `key`).
   - `key` – Ruta a un archivo de clave privada SSH (opcional).
   - `port` – (Opcional) Puerto SSH (por defecto `22`).
+
+### Desactivar entidades
+
+Añade las claves de sensores no deseados en `disabled_entities` para evitar su creación y publicación. Por ejemplo, para desactivar los sensores de temperatura y lista de paquetes:
+
+```yaml
+disabled_entities:
+  - temp
+  - pkg_list
+```
 
 ---
 
@@ -138,6 +160,9 @@ Para cada servidor estarán disponibles las siguientes entidades:
 - `sensor.<name>_pkg_list` – Actualizaciones pendientes (primeras 10)
 - `sensor.<name>_docker` – 1 si Docker está instalado, 0 en caso contrario
 - `sensor.<name>_containers` – Contenedores Docker en ejecución (lista separada por comas)
+- `sensor.<name>_vnc` – "sí" si se detecta un servidor VNC
+- `sensor.<name>_web` – "sí" si escucha un servicio HTTP o HTTPS
+- `sensor.<name>_ssh` – "sí" si el servicio SSH está activo
 - Para cada contenedor en ejecución: `sensor.<name>_container_<container>_cpu` (uso de CPU %) y `sensor.<name>_container_<container>_mem` (uso de memoria %)
 
 ---

--- a/README.fr.md
+++ b/README.fr.md
@@ -12,6 +12,8 @@ Alternativement, l'intégration HACS peut interroger vos serveurs directement vi
 
 Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque, temps de fonctionnement, débit réseau et température de tous vos serveurs dans les tableaux de bord Home Assistant.
 
+En plus de la collecte de statistiques, le module inclut désormais un terminal web interactif et un service Home Assistant pour exécuter des commandes ad hoc sur vos serveurs.
+
 ---
 
 ## Fonctionnalités
@@ -19,6 +21,8 @@ Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque,
 - Prise en charge de plusieurs serveurs avec configuration individuelle.
 - Configurable via l'interface Home Assistant (config flow).
 - Prise en charge de l'authentification par mot de passe et par clé SSH.
+- Terminal interactif accessible via l'interface web du module.
+- Services Home Assistant et entités bouton pour exécuter des commandes à distance, mettre à jour les paquets et redémarrer.
 - Collecte :
   - Utilisation du CPU (%)
   - Utilisation de la mémoire (%)
@@ -33,9 +37,13 @@ Cela permet d'afficher en temps réel les informations de CPU, mémoire, disque,
   - Version du système d'exploitation
   - Paquets installés (nombre et liste)
   - Détection de Docker, conteneurs en cours d'exécution et utilisation par conteneur (CPU et mémoire)
+  - Statut du support VNC
+  - Statut du serveur web HTTP/HTTPS
+  - Statut du service SSH
 - **MQTT Discovery** automatique pour une intégration facile avec Home Assistant.
 - Intervalle de mise à jour configurable (par défaut : 30 secondes).
 - Interface web légère optionnelle pouvant être affichée dans la barre latérale de Home Assistant, maintenant avec un onglet pour les conteneurs Docker.
+- Services pour obtenir l'adresse IP locale du serveur, le temps de fonctionnement, lister les connexions SSH actives, exécuter des commandes, mettre à jour les paquets et redémarrer l'hôte.
 
 ### Utilisation autonome sans MQTT
 
@@ -89,6 +97,9 @@ mqtt_port: 1883
 mqtt_user: mqttuser
 mqtt_pass: mqttpassword
 interval_seconds: 30
+disabled_entities:
+  - pkg_list
+  - temp
 servers:
   - name: "pi5"
     host: "192.168.1.10"
@@ -106,6 +117,7 @@ servers:
 - **mqtt_port** – Port du broker MQTT (par défaut : `1883`).
 - **mqtt_user / mqtt_pass** – Identifiants MQTT.
 - **interval_seconds** – Intervalle d'interrogation en secondes (minimum 5).
+- **disabled_entities** – Liste des clés de capteurs à désactiver (par ex. `cpu`, `mem`). Toutes activées par défaut.
 - **servers** – Liste des serveurs à surveiller :
   - `name` – Nom convivial (utilisé comme préfixe d'entité).
   - `host` – Adresse IP ou nom d'hôte du serveur.
@@ -113,6 +125,16 @@ servers:
   - `password` – Mot de passe SSH (facultatif si `key` est utilisé).
   - `key` – Chemin vers un fichier de clé privée SSH (facultatif).
   - `port` – (Facultatif) Port SSH (par défaut `22`).
+
+### Désactivation des entités
+
+Ajoutez les clés de capteurs indésirables dans `disabled_entities` pour éviter leur création et leur publication. Par exemple, pour désactiver les capteurs de température et de liste de paquets :
+
+```yaml
+disabled_entities:
+  - temp
+  - pkg_list
+```
 
 ---
 
@@ -138,6 +160,9 @@ Pour chaque serveur, les entités suivantes seront disponibles :
 - `sensor.<name>_pkg_list` – Mises à jour en attente (10 premières)
 - `sensor.<name>_docker` – 1 si Docker est installé, 0 sinon
 - `sensor.<name>_containers` – Conteneurs Docker en cours d'exécution (liste séparée par des virgules)
+- `sensor.<name>_vnc` – "oui" si un serveur VNC est détecté
+- `sensor.<name>_web` – "oui" si un service HTTP ou HTTPS est à l'écoute
+- `sensor.<name>_ssh` – "oui" si le service SSH est actif
 - Pour chaque conteneur en cours d'exécution : `sensor.<name>_container_<container>_cpu` (utilisation CPU %) et `sensor.<name>_container_<container>_mem` (utilisation mémoire %)
 
 ---


### PR DESCRIPTION
## Summary
- sync German README with new SSH service capabilities
- expand Spanish and French READMEs with interactive terminal, services, disabled_entities, and new sensor docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba6a89ef9c83279ff2bbc059e92b24