### PR TITLE
fix: ensure service checks always set status values

### DIFF
--- a/addon/vserver_ssh_stats/app/remote_script.py
+++ b/addon/vserver_ssh_stats/app/remote_script.py
@@ -97,24 +97,22 @@ elif command -v netstat >/dev/null 2>&1; then
   sock_cmd="netstat -tuln"
 fi
 
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':22\\s' >/dev/null; then
-  ssh_enabled="yes"
-else
-  ssh_enabled="no"
+ssh_enabled="no"
+web="no"
+vnc="no"
+if [ -n "$sock_cmd" ]; then
+  if $sock_cmd 2>/dev/null | grep -E ':22\\s' >/dev/null; then
+    ssh_enabled="yes"
+  fi
+  if $sock_cmd 2>/dev/null | grep -E ':(80|443)\\s' >/dev/null; then
+    web="yes"
+  fi
+  if $sock_cmd 2>/dev/null | grep -E ':5900\\s' >/dev/null; then
+    vnc="yes"
+  fi
 fi
-
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':(80|443)\\s' >/dev/null; then
-  web="yes"
-else
-  web="no"
-fi
-
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':5900\\s' >/dev/null; then
+if [ "$vnc" = "no" ] && (command -v vncserver >/dev/null 2>&1 || command -v x11vnc >/dev/null 2>&1); then
   vnc="yes"
-elif command -v vncserver >/dev/null 2>&1 || command -v x11vnc >/dev/null 2>&1; then
-  vnc="yes"
-else
-  vnc="no"
 fi
 
 # TEMP (°C, best-effort)

--- a/custom_components/vserver_ssh_stats/remote_script.py
+++ b/custom_components/vserver_ssh_stats/remote_script.py
@@ -99,24 +99,22 @@ elif command -v netstat >/dev/null 2>&1; then
   sock_cmd="netstat -tuln"
 fi
 
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':22\\s' >/dev/null; then
-  ssh_enabled="yes"
-else
-  ssh_enabled="no"
+ssh_enabled="no"
+web="no"
+vnc="no"
+if [ -n "$sock_cmd" ]; then
+  if $sock_cmd 2>/dev/null | grep -E ':22\\s' >/dev/null; then
+    ssh_enabled="yes"
+  fi
+  if $sock_cmd 2>/dev/null | grep -E ':(80|443)\\s' >/dev/null; then
+    web="yes"
+  fi
+  if $sock_cmd 2>/dev/null | grep -E ':5900\\s' >/dev/null; then
+    vnc="yes"
+  fi
 fi
-
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':(80|443)\\s' >/dev/null; then
-  web="yes"
-else
-  web="no"
-fi
-
-if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':5900\\s' >/dev/null; then
+if [ "$vnc" = "no" ] && (command -v vncserver >/dev/null 2>&1 || command -v x11vnc >/dev/null 2>&1); then
   vnc="yes"
-elif command -v vncserver >/dev/null 2>&1 || command -v x11vnc >/dev/null 2>&1; then
-  vnc="yes"
-else
-  vnc="no"
 fi
 
 # TEMP (°C, best-effort)


### PR DESCRIPTION
## Summary
- avoid missing SSH/Web/VNC status by initializing service checks
- mirror service check fixes in add-on script

## Testing
- `python -m py_compile custom_components/vserver_ssh_stats/remote_script.py addon/vserver_ssh_stats/app/remote_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68badb3541c483279d5bb91117a5b4e8