### PR TITLE
Add Zeroconf discovery

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Zusätzlich steht nun ein **interaktives Terminal** über die Weboberfläche zur
 - Unterstützt Passwort- und SSH-Schlüssel-Authentifizierung.
 - Interaktives Terminal über die Add-on-Weboberfläche.
 - Home-Assistant-Services und Schaltflächen zum Ausführen von Befehlen, Paket-Updates und Reboots.
-- Automatische Erkennung von SSH-fähigen Hosts im lokalen Netzwerk zur schnellen Einrichtung, manuelle Konfiguration bleibt weiterhin möglich.
+- Automatische Erkennung von SSH-fähigen Hosts im lokalen Netzwerk zur schnellen Einrichtung, manuelle Konfiguration bleibt weiterhin möglich. Kompatible Server, die sich per Zeroconf ankündigen, erscheinen außerdem im Bereich **Entdeckt** von Home Assistant.
 - Sammelt:
   - CPU-Auslastung (%)
   - Speicherauslastung (%)

--- a/README.es.md
+++ b/README.es.md
@@ -23,7 +23,7 @@ Además de la recopilación de estadísticas, el complemento incluye ahora un te
 - Soporta autenticación por contraseña y por clave SSH.
 - Terminal interactivo accesible desde la interfaz web del complemento.
 - Servicios de Home Assistant y entidades de botón para ejecutar comandos remotos, actualizar paquetes y reiniciar.
-- Detecta automáticamente hosts con SSH en la red local para una configuración rápida, manteniendo la posibilidad de configuración manual.
+- Detecta automáticamente hosts con SSH en la red local para una configuración rápida, manteniendo la posibilidad de configuración manual. Los servidores compatibles que se anuncian mediante Zeroconf también aparecen en la sección **Descubierto** de Home Assistant.
 - Recopila:
   - Uso de CPU (%)
   - Uso de memoria (%)

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,7 +23,7 @@ En plus de la collecte de statistiques, le module inclut désormais un terminal 
 - Prise en charge de l'authentification par mot de passe et par clé SSH.
 - Terminal interactif accessible via l'interface web du module.
 - Services Home Assistant et entités bouton pour exécuter des commandes à distance, mettre à jour les paquets et redémarrer.
-- Détecte automatiquement les hôtes compatibles SSH sur le réseau local pour une configuration rapide, tout en permettant une configuration manuelle.
+- Détecte automatiquement les hôtes compatibles SSH sur le réseau local pour une configuration rapide, tout en permettant une configuration manuelle. Les serveurs compatibles s'annonçant via Zeroconf apparaissent également dans la section **Découvert** de Home Assistant.
 - Collecte :
   - Utilisation du CPU (%)
   - Utilisation de la mémoire (%)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In addition to statistics collection, the add-on now includes an **interactive w
 - Supports password and SSH key authentication.
 - Interactive terminal accessible via the add-on web UI.
 - Home Assistant services and button entities for remote commands, package updates, and reboots.
-- Automatically discovers SSH-enabled hosts on your local network for quick setup, while still allowing manual configuration.
+- Automatically discovers SSH-enabled hosts on your local network for quick setup, while still allowing manual configuration. Compatible servers announcing themselves via Zeroconf also appear under Home Assistant's **Discovered** section.
 - Collects:
   - CPU usage (%)
   - Memory usage (%)

--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -19,6 +19,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered_host: str | None = None
+        self._discovered_name: str | None = None
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
         if user_input is not None:
@@ -49,8 +54,22 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         hosts = await self._get_discovered_hosts()
         return self.async_show_form(step_id="user", data_schema=self._build_schema(hosts))
 
+    async def async_step_zeroconf(self, discovery_info: dict[str, Any]):
+        """Handle zeroconf discovery."""
+        host = discovery_info.get("host")
+        if not host:
+            return self.async_abort(reason="unknown")
+        self._discovered_host = host
+        self._discovered_name = discovery_info.get("hostname", host)
+        self.context["title_placeholders"] = {"name": self._discovered_name}
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured()
+        return await self.async_step_user()
+
     async def _get_discovered_hosts(self) -> list[str]:
         """Return a list of hosts with an open SSH port."""
+        if self._discovered_host:
+            return [self._discovered_host]
         network = guess_local_network()
         try:
             return await discover_ssh_hosts(network)
@@ -73,10 +92,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             host_field = str
             default_host = vol.UNDEFINED
+        default_name = self._discovered_name if self._discovered_name else vol.UNDEFINED
         return vol.Schema(
             {
                 vol.Required("interval", default=DEFAULT_INTERVAL): int,
-                vol.Required("name"): str,
+                vol.Required("name", default=default_name): str,
                 vol.Required("host", default=default_host): host_field,
                 vol.Required("username"): str,
                 vol.Optional("password"): str,

--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -5,6 +5,9 @@
     "@404GamerNotFound"
   ],
   "config_flow": true,
+  "zeroconf": [
+    {"type": "_ssh._tcp.local."}
+  ],
   "documentation": "https://github.com/404GamerNotFound/vserver-ssh-stats",
   "integration_type": "service",
   "iot_class": "local_polling",


### PR DESCRIPTION
## Summary
- support Zeroconf discovery so SSH servers broadcasted by mDNS appear under Home Assistant's "Discovered" section
- document Zeroconf-based discovery in README translations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6897ecdf88327b3cf6963611a11a6