### PR TITLE
fix: skip config version when missing

### DIFF
--- a/custom_components/vserver_ssh_stats/manifest.json
+++ b/custom_components/vserver_ssh_stats/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "paramiko>=3.4.0"
   ],
-  "version": "1.2.5",
+  "version": "1.2.6",
   "zeroconf": [
     {
       "type": "_ssh._tcp.local."

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -17,6 +17,8 @@ def update_manifest(new_version: str):
     MANIFEST_PATH.write_text(json.dumps(data, indent=2) + "\n")
 
 def update_config(new_version: str):
+    if not CONFIG_PATH.exists():
+        return
     text = CONFIG_PATH.read_text()
     text = re.sub(r'version:\s*"\d+\.\d+\.\d+"', f'version: "{new_version}"', text)
     CONFIG_PATH.write_text(text)


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError in bump_version script when addon config is absent
- bump integration version to 1.2.6

## Testing
- `python scripts/bump_version.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a09a4eb083279b99318a031e8a92