### PR TITLE
Add port and multi-server configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v1.2.7
+- Added configurable SSH port support to the onboarding flow and stored server definitions.
+- Enabled multi-server setup directly from the UI and provided an options flow to edit the list later on.
+- Introduced Home Assistant diagnostics support to aid HACS quality requirements.
+- Documented sudo requirements for remote actions and added release management guidance.

--- a/README.de.md
+++ b/README.de.md
@@ -107,6 +107,15 @@ cards:
 ## Sicherheitshinweise
 - Es wird empfohlen, einen dedizierten, eingeschränkten Benutzer für das SSH-Monitoring zu erstellen (mit nur Lesezugriff auf `/proc` und `df`).
 - SSH-Passwortauthentifizierung wird unterstützt, aber **SSH-Schlüssel-Authentifizierung** wird für den produktiven Einsatz dringend empfohlen.
+- Remote-Aktionen wie Paketaktualisierungen und Neustarts nutzen `sudo`. Stellen Sie sicher, dass das entfernte Konto `apt-get`, `dnf`, `yum` und `reboot` ohne Passwortabfrage ausführen darf (z. B. durch gezielte Einträge in der `/etc/sudoers`). Dokumentieren oder härten Sie diese Rechte pro Server ab, bevor Sie die Buttons/Services einsetzen.
+
+---
+
+## Release-Management
+- Aktuelle stabile Version: **v1.2.7** (siehe `manifest.json`).
+- Erstellen Sie für jede veröffentlichte Version ein Git-Tag (z. B. `git tag v1.2.7`) sowie ein zugehöriges GitHub-Release, damit HACS Updates sauber nachvollziehen kann.
+- Nutzen Sie das vorhandene Skript `scripts/bump_version.py`, um die Versionsnummer der Integration vor einer neuen Veröffentlichung zu erhöhen.
+- Pflegen Sie wichtige Änderungen zusätzlich in der [`CHANGELOG.md`](CHANGELOG.md).
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -107,6 +107,15 @@ cards:
 ## Notas de seguridad
 - Se recomienda crear un usuario dedicado y restringido para la supervisión por SSH (con acceso de solo lectura a `/proc` y `df`).
 - Se admite autenticación por contraseña, pero se recomienda encarecidamente la **autenticación por clave SSH** para uso en producción.
+- Las acciones remotas como las actualizaciones de paquetes y los reinicios usan `sudo`. Asegúrate de que la cuenta remota pueda ejecutar `apt-get`, `dnf`, `yum` y `reboot` sin solicitar contraseña (por ejemplo, añadiendo reglas explícitas en `/etc/sudoers`). Documenta o refuerza esos permisos en cada servidor antes de habilitar los botones/servicios.
+
+---
+
+## Gestión de lanzamientos
+- Versión estable actual: **v1.2.7** (coincide con `manifest.json`).
+- Crea una etiqueta Git (por ejemplo, `git tag v1.2.7`) y una versión en GitHub para cada lanzamiento a fin de que HACS pueda seguir las actualizaciones correctamente.
+- Utiliza el script existente `scripts/bump_version.py` para incrementar la versión de la integración al preparar una nueva publicación.
+- Registra los cambios relevantes en [`CHANGELOG.md`](CHANGELOG.md) junto con cada versión.
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -107,6 +107,15 @@ cards:
 ## Notes de sécurité
 - Il est recommandé de créer un utilisateur dédié et restreint pour la surveillance SSH (avec un accès en lecture seule à `/proc` et `df`).
 - L'authentification par mot de passe est prise en charge, mais l'**authentification par clé SSH** est fortement recommandée pour un usage en production.
+- Les actions distantes telles que les mises à jour de paquets et les redémarrages utilisent `sudo`. Assurez-vous que le compte distant peut exécuter `apt-get`, `dnf`, `yum` et `reboot` sans invite de mot de passe (par exemple via des règles explicites dans `/etc/sudoers`). Documentez ou sécurisez ces droits sur chaque serveur avant d'activer les boutons/services.
+
+---
+
+## Gestion des versions
+- Version stable actuelle : **v1.2.7** (conforme à `manifest.json`).
+- Créez une étiquette Git (par exemple `git tag v1.2.7`) et une publication GitHub pour chaque version afin que HACS puisse suivre correctement les mises à jour.
+- Utilisez le script `scripts/bump_version.py` existant pour incrémenter la version de l'intégration lors de la préparation d'une nouvelle publication.
+- Consignez les changements importants dans [`CHANGELOG.md`](CHANGELOG.md) pour chaque version.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,17 @@ cards:
 ```
 
 ## Security Notes
-- It is recommended to create a dedicated, restricted user for SSH monitoring (with read-only access to `/proc` and `df`).  
-- SSH password authentication is supported, but **SSH key authentication** is strongly recommended for production use.  
+- It is recommended to create a dedicated, restricted user for SSH monitoring (with read-only access to `/proc` and `df`).
+- SSH password authentication is supported, but **SSH key authentication** is strongly recommended for production use.
+- Remote actions such as package upgrades and reboots rely on `sudo`. Ensure the remote account is permitted to execute `apt-get`, `dnf`, `yum`, and `reboot` without an interactive password prompt (for example by adding explicit rules to `/etc/sudoers`). Document or harden those permissions for each monitored server before enabling the buttons/services.
+
+---
+
+## Release Management
+- Current stable release: **v1.2.7** (matching `manifest.json`).
+- Create a Git tag (e.g. `git tag v1.2.7`) and a corresponding GitHub release for every published version so HACS can track updates reliably.
+- Use the existing `scripts/bump_version.py` helper to increment the integration version when preparing a new release.
+- Document notable changes in [`CHANGELOG.md`](CHANGELOG.md) alongside each release.
 
 ---
 

--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -1,17 +1,59 @@
 """Config flow for VServer SSH Stats."""
 from __future__ import annotations
 
-from typing import Any
+import hashlib
 import json
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from . import DOMAIN
 from .ssh_discovery import discover_ssh_hosts, guess_local_network
 
 DEFAULT_INTERVAL = 30
+
+
+def _build_server_schema(
+    hosts: list[str],
+    include_interval: bool,
+    interval_default: int,
+    default_name: Any,
+    defaults: dict[str, Any] | None = None,
+) -> vol.Schema:
+    """Create the data schema for a single server entry."""
+
+    defaults = defaults or {}
+    host_field: Any
+    default_host: Any
+    if hosts:
+        host_field = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[selector.SelectOptionDict(value=h, label=h) for h in hosts],
+                custom_value=True,
+            )
+        )
+        default_host = hosts[0]
+    else:
+        host_field = str
+        default_host = vol.UNDEFINED
+
+    schema: dict[Any, Any] = {}
+    if include_interval:
+        schema[vol.Required("interval", default=defaults.get("interval", interval_default))] = int
+
+    schema[vol.Required("name", default=defaults.get("name", default_name))] = str
+    schema[vol.Required("host", default=defaults.get("host", default_host))] = host_field
+    schema[vol.Required("port", default=defaults.get("port", 22))] = vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=65535)
+    )
+    schema[vol.Required("username", default=defaults.get("username", vol.UNDEFINED))] = str
+    schema[vol.Optional("password")] = str
+    schema[vol.Optional("key")] = str
+    schema[vol.Optional("add_another", default=defaults.get("add_another", False))] = bool
+    return vol.Schema(schema)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -23,47 +65,91 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovered_host: str | None = None
         self._discovered_name: str | None = None
+        self._servers: list[dict[str, Any]] = []
+        self._interval: int = DEFAULT_INTERVAL
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
+
+        errors: dict[str, str] = {}
+        defaults = user_input or {}
+        first_server = not self._servers
+
         if user_input is not None:
+            if first_server:
+                self._interval = user_input["interval"]
             if not user_input.get("password") and not user_input.get("key"):
-                hosts = await self._get_discovered_hosts()
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=self._build_schema(hosts),
-                    errors={"base": "auth"},
-                )
-            server: dict[str, Any] = {
-                "name": user_input["name"],
-                "host": user_input["host"],
-                "username": user_input["username"],
-            }
-            if user_input.get("password"):
-                server["password"] = user_input["password"]
-            if user_input.get("key"):
-                server["key"] = user_input["key"]
-            data = {
-                "interval": user_input["interval"],
-                "servers_json": json.dumps([server]),
-            }
-            await self.async_set_unique_id(server["host"])  # Prevent duplicate hosts
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=server["name"], data=data)
+                errors["base"] = "auth"
+            else:
+                host = user_input["host"]
+                if any(server["host"] == host for server in self._servers):
+                    errors["host"] = "duplicate_host"
+                elif self._host_already_configured(host):
+                    errors["host"] = "host_in_use"
+                else:
+                    server: dict[str, Any] = {
+                        "name": user_input["name"],
+                        "host": host,
+                        "username": user_input["username"],
+                        "port": user_input["port"],
+                    }
+                    if user_input.get("password"):
+                        server["password"] = user_input["password"]
+                    if user_input.get("key"):
+                        server["key"] = user_input["key"]
+                    self._servers.append(server)
+                    if user_input.get("add_another"):
+                        hosts = await self._get_discovered_hosts()
+                        return self.async_show_form(
+                            step_id="user",
+                            data_schema=_build_server_schema(
+                                hosts,
+                                include_interval=False,
+                                interval_default=self._interval,
+                                default_name=vol.UNDEFINED,
+                            ),
+                        )
+
+                    hosts_for_id = ",".join(sorted(server["host"] for server in self._servers))
+                    unique_id = hashlib.sha256(hosts_for_id.encode()).hexdigest()
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+                    data = {
+                        "interval": self._interval,
+                        "servers_json": json.dumps(self._servers),
+                    }
+                    title = (
+                        self._servers[0]["name"]
+                        if len(self._servers) == 1
+                        else "VServer SSH Stats"
+                    )
+                    return self.async_create_entry(title=title, data=data)
 
         hosts = await self._get_discovered_hosts()
-        return self.async_show_form(step_id="user", data_schema=self._build_schema(hosts))
+        default_name = self._discovered_name if first_server else vol.UNDEFINED
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_build_server_schema(
+                hosts,
+                include_interval=first_server,
+                interval_default=self._interval,
+                default_name=default_name,
+                defaults=defaults,
+            ),
+            errors=errors,
+        )
 
     async def async_step_zeroconf(self, discovery_info: dict[str, Any]):
         """Handle zeroconf discovery."""
+
         host = discovery_info.get("host")
         if not host:
             return self.async_abort(reason="unknown")
+        if self._host_already_configured(host):
+            return self.async_abort(reason="already_configured")
         self._discovered_host = host
         self._discovered_name = discovery_info.get("hostname", host)
         self.context["title_placeholders"] = {"name": self._discovered_name}
-        await self.async_set_unique_id(host)
-        self._abort_if_unique_id_configured()
         return await self.async_step_user()
 
     async def _get_discovered_hosts(self) -> list[str]:
@@ -93,29 +179,172 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return sorted(hosts)
 
-    def _build_schema(self, hosts: list[str]) -> vol.Schema:
-        """Create the data schema for the form using *hosts* if provided."""
-        host_field: Any
-        default_host: Any
-        if hosts:
-            host_field = selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=[selector.SelectOptionDict(value=h, label=h) for h in hosts],
-                    custom_value=True,
-                )
+    def _host_already_configured(self, host: str) -> bool:
+        """Return True if *host* is already configured in another entry."""
+
+        for entry in self._async_current_entries():
+            try:
+                servers = json.loads(entry.data.get("servers_json", "[]"))
+            except ValueError:
+                continue
+            if any(server.get("host") == host for server in servers):
+                return True
+        return False
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Return the options flow handler for this config entry."""
+
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for VServer SSH Stats."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialise the options flow."""
+
+        self.config_entry = config_entry
+        self._interval: int = config_entry.data.get("interval", DEFAULT_INTERVAL)
+        try:
+            self._existing_servers: list[dict[str, Any]] = json.loads(
+                config_entry.data.get("servers_json", "[]")
             )
-            default_host = hosts[0]
-        else:
-            host_field = str
-            default_host = vol.UNDEFINED
-        default_name = self._discovered_name if self._discovered_name else vol.UNDEFINED
-        return vol.Schema(
-            {
-                vol.Required("interval", default=DEFAULT_INTERVAL): int,
-                vol.Required("name", default=default_name): str,
-                vol.Required("host", default=default_host): host_field,
-                vol.Required("username"): str,
-                vol.Optional("password"): str,
-                vol.Optional("key"): str,
-            }
+        except ValueError:
+            self._existing_servers = []
+        self._pending_servers: list[dict[str, Any]] = []
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Manage the initial options step."""
+
+        if user_input is not None:
+            self._interval = user_input["interval"]
+            if user_input.get("reconfigure_servers"):
+                hosts = await self._get_discovered_hosts()
+                return self.async_show_form(
+                    step_id="servers",
+                    data_schema=_build_server_schema(
+                        hosts,
+                        include_interval=False,
+                        interval_default=self._interval,
+                        default_name=vol.UNDEFINED,
+                    ),
+                )
+
+            self._update_entry(self._existing_servers)
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("interval", default=self._interval): vol.All(
+                        vol.Coerce(int), vol.Range(min=1)
+                    ),
+                    vol.Optional("reconfigure_servers", default=False): bool,
+                }
+            ),
         )
+
+    async def async_step_servers(self, user_input: dict[str, Any] | None = None):
+        """Collect server information during options flow."""
+
+        errors: dict[str, str] = {}
+        defaults = user_input or {}
+
+        if user_input is not None:
+            if not user_input.get("password") and not user_input.get("key"):
+                errors["base"] = "auth"
+            else:
+                host = user_input["host"]
+                if any(server["host"] == host for server in self._pending_servers):
+                    errors["host"] = "duplicate_host"
+                elif self._host_already_configured(host):
+                    errors["host"] = "host_in_use"
+                else:
+                    server: dict[str, Any] = {
+                        "name": user_input["name"],
+                        "host": host,
+                        "username": user_input["username"],
+                        "port": user_input["port"],
+                    }
+                    if user_input.get("password"):
+                        server["password"] = user_input["password"]
+                    if user_input.get("key"):
+                        server["key"] = user_input["key"]
+                    self._pending_servers.append(server)
+                    if user_input.get("add_another"):
+                        hosts = await self._get_discovered_hosts()
+                        return self.async_show_form(
+                            step_id="servers",
+                            data_schema=_build_server_schema(
+                                hosts,
+                                include_interval=False,
+                                interval_default=self._interval,
+                                default_name=vol.UNDEFINED,
+                            ),
+                        )
+
+                    self._update_entry(self._pending_servers)
+                    return self.async_create_entry(title="", data={})
+
+        hosts = await self._get_discovered_hosts()
+        return self.async_show_form(
+            step_id="servers",
+            data_schema=_build_server_schema(
+                hosts,
+                include_interval=False,
+                interval_default=self._interval,
+                default_name=vol.UNDEFINED,
+                defaults=defaults,
+            ),
+            errors=errors,
+        )
+
+    def _update_entry(self, servers: list[dict[str, Any]]) -> None:
+        """Persist updated configuration back to the config entry."""
+
+        data = {
+            "interval": self._interval,
+            "servers_json": json.dumps(servers),
+        }
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        )
+
+    async def _get_discovered_hosts(self) -> list[str]:
+        """Return a list of hosts with an open SSH port."""
+
+        networks: list[str] = []
+        try:
+            from homeassistant.helpers.network import async_get_ipv4_addresses
+
+            addresses = await async_get_ipv4_addresses(self.hass, include_loopback=False)
+            networks = [f"{addr}/24" for addr in addresses]
+        except Exception:  # pragma: no cover - helper not available
+            networks = [guess_local_network()]
+
+        hosts: set[str] = set()
+        for network in networks:
+            try:
+                hosts.update(await discover_ssh_hosts(network))
+            except OSError:
+                continue
+
+        return sorted(hosts)
+
+    def _host_already_configured(self, host: str) -> bool:
+        """Return True if *host* is already configured in another entry."""
+
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.entry_id == self.config_entry.entry_id:
+                continue
+            try:
+                servers = json.loads(entry.data.get("servers_json", "[]"))
+            except ValueError:
+                continue
+            if any(server.get("host") == host for server in servers):
+                return True
+        return False

--- a/custom_components/vserver_ssh_stats/diagnostics.py
+++ b/custom_components/vserver_ssh_stats/diagnostics.py
@@ -1,0 +1,42 @@
+"""Diagnostics support for VServer SSH Stats."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from . import DOMAIN
+
+TO_REDACT = {"host", "username", "password", "key"}
+
+
+def _load_servers(entry: ConfigEntry) -> list[dict[str, Any]]:
+    """Safely load server definitions from a config entry."""
+
+    try:
+        return json.loads(entry.data.get("servers_json", "[]"))
+    except ValueError:
+        return []
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    servers = _load_servers(config_entry)
+    redacted_servers = [async_redact_data(server, TO_REDACT) for server in servers]
+    return {
+        "entry": {
+            "title": config_entry.title,
+            "entry_id": config_entry.entry_id,
+            "unique_id": config_entry.unique_id,
+            "interval": config_entry.data.get("interval"),
+        },
+        "servers": redacted_servers,
+        "options": config_entry.options,
+        "domain": DOMAIN,
+    }

--- a/custom_components/vserver_ssh_stats/strings.json
+++ b/custom_components/vserver_ssh_stats/strings.json
@@ -5,17 +5,49 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "interval": "Interval",
-          "name": "Name",
+          "interval": "Update interval (seconds)",
+          "name": "Server name",
           "host": "Host",
+          "port": "SSH port",
           "username": "Username",
           "password": "Password",
-          "key": "Key file"
+          "key": "Key file",
+          "add_another": "Add another server after this"
         }
       }
     },
     "error": {
-      "auth": "Provide password or key file"
+      "auth": "Provide password or key file",
+      "duplicate_host": "This host was already added",
+      "host_in_use": "This host is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "interval": "Update interval (seconds)",
+          "reconfigure_servers": "Re-enter the server list"
+        }
+      },
+      "servers": {
+        "title": "VServer SSH Stats",
+        "description": "Add servers one by one. Choose 'Add another server' to continue entering hosts.",
+        "data": {
+          "name": "Server name",
+          "host": "Host",
+          "port": "SSH port",
+          "username": "Username",
+          "password": "Password",
+          "key": "Key file",
+          "add_another": "Add another server after this"
+        }
+      }
+    },
+    "error": {
+      "auth": "Provide password or key file",
+      "duplicate_host": "This host was already added",
+      "host_in_use": "This host is already configured"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/de.json
+++ b/custom_components/vserver_ssh_stats/translations/de.json
@@ -5,17 +5,49 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "interval": "Intervall",
-          "name": "Name",
+          "interval": "Aktualisierungsintervall (Sekunden)",
+          "name": "Servername",
           "host": "Host",
+          "port": "SSH-Port",
           "username": "Benutzername",
           "password": "Passwort",
-          "key": "Schlüsseldatei"
+          "key": "Schlüsseldatei",
+          "add_another": "Weiteren Server danach hinzufügen"
         }
       }
     },
     "error": {
-      "auth": "Passwort oder Schlüsseldatei angeben"
+      "auth": "Passwort oder Schlüsseldatei angeben",
+      "duplicate_host": "Dieser Host wurde bereits hinzugefügt",
+      "host_in_use": "Dieser Host ist bereits konfiguriert"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "interval": "Aktualisierungsintervall (Sekunden)",
+          "reconfigure_servers": "Serverliste erneut eingeben"
+        }
+      },
+      "servers": {
+        "title": "VServer SSH Stats",
+        "description": "Server einzeln hinzufügen. Wählen Sie 'Weiteren Server danach hinzufügen', um weitere Hosts einzutragen.",
+        "data": {
+          "name": "Servername",
+          "host": "Host",
+          "port": "SSH-Port",
+          "username": "Benutzername",
+          "password": "Passwort",
+          "key": "Schlüsseldatei",
+          "add_another": "Weiteren Server danach hinzufügen"
+        }
+      }
+    },
+    "error": {
+      "auth": "Passwort oder Schlüsseldatei angeben",
+      "duplicate_host": "Dieser Host wurde bereits hinzugefügt",
+      "host_in_use": "Dieser Host ist bereits konfiguriert"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/en.json
+++ b/custom_components/vserver_ssh_stats/translations/en.json
@@ -5,17 +5,49 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "interval": "Interval",
-          "name": "Name",
+          "interval": "Update interval (seconds)",
+          "name": "Server name",
           "host": "Host",
+          "port": "SSH port",
           "username": "Username",
           "password": "Password",
-          "key": "Key file"
+          "key": "Key file",
+          "add_another": "Add another server after this"
         }
       }
     },
     "error": {
-      "auth": "Provide password or key file"
+      "auth": "Provide password or key file",
+      "duplicate_host": "This host was already added",
+      "host_in_use": "This host is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "interval": "Update interval (seconds)",
+          "reconfigure_servers": "Re-enter the server list"
+        }
+      },
+      "servers": {
+        "title": "VServer SSH Stats",
+        "description": "Add servers one by one. Choose 'Add another server' to continue entering hosts.",
+        "data": {
+          "name": "Server name",
+          "host": "Host",
+          "port": "SSH port",
+          "username": "Username",
+          "password": "Password",
+          "key": "Key file",
+          "add_another": "Add another server after this"
+        }
+      }
+    },
+    "error": {
+      "auth": "Provide password or key file",
+      "duplicate_host": "This host was already added",
+      "host_in_use": "This host is already configured"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/es.json
+++ b/custom_components/vserver_ssh_stats/translations/es.json
@@ -5,17 +5,49 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "interval": "Intervalo",
-          "name": "Nombre",
+          "interval": "Intervalo de actualización (segundos)",
+          "name": "Nombre del servidor",
           "host": "Host",
+          "port": "Puerto SSH",
           "username": "Usuario",
           "password": "Contraseña",
-          "key": "Archivo de clave"
+          "key": "Archivo de clave",
+          "add_another": "Agregar otro servidor después de este"
         }
       }
     },
     "error": {
-      "auth": "Proporcione contraseña o archivo de clave"
+      "auth": "Proporcione contraseña o archivo de clave",
+      "duplicate_host": "Este host ya se añadió",
+      "host_in_use": "Este host ya está configurado"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "interval": "Intervalo de actualización (segundos)",
+          "reconfigure_servers": "Volver a introducir la lista de servidores"
+        }
+      },
+      "servers": {
+        "title": "VServer SSH Stats",
+        "description": "Agrega servidores uno a uno. Selecciona 'Agregar otro servidor después de este' para seguir introduciendo hosts.",
+        "data": {
+          "name": "Nombre del servidor",
+          "host": "Host",
+          "port": "Puerto SSH",
+          "username": "Usuario",
+          "password": "Contraseña",
+          "key": "Archivo de clave",
+          "add_another": "Agregar otro servidor después de este"
+        }
+      }
+    },
+    "error": {
+      "auth": "Proporcione contraseña o archivo de clave",
+      "duplicate_host": "Este host ya se añadió",
+      "host_in_use": "Este host ya está configurado"
     }
   }
 }

--- a/custom_components/vserver_ssh_stats/translations/fr.json
+++ b/custom_components/vserver_ssh_stats/translations/fr.json
@@ -5,17 +5,49 @@
       "user": {
         "title": "VServer SSH Stats",
         "data": {
-          "interval": "Intervalle",
-          "name": "Nom",
+          "interval": "Intervalle de mise à jour (secondes)",
+          "name": "Nom du serveur",
           "host": "Hôte",
+          "port": "Port SSH",
           "username": "Nom d'utilisateur",
           "password": "Mot de passe",
-          "key": "Fichier de clé"
+          "key": "Fichier de clé",
+          "add_another": "Ajouter un autre serveur après celui-ci"
         }
       }
     },
     "error": {
-      "auth": "Fournissez un mot de passe ou un fichier de clé"
+      "auth": "Fournissez un mot de passe ou un fichier de clé",
+      "duplicate_host": "Cet hôte a déjà été ajouté",
+      "host_in_use": "Cet hôte est déjà configuré"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "interval": "Intervalle de mise à jour (secondes)",
+          "reconfigure_servers": "Saisir à nouveau la liste des serveurs"
+        }
+      },
+      "servers": {
+        "title": "VServer SSH Stats",
+        "description": "Ajoutez les serveurs un par un. Choisissez 'Ajouter un autre serveur après celui-ci' pour continuer.",
+        "data": {
+          "name": "Nom du serveur",
+          "host": "Hôte",
+          "port": "Port SSH",
+          "username": "Nom d'utilisateur",
+          "password": "Mot de passe",
+          "key": "Fichier de clé",
+          "add_another": "Ajouter un autre serveur après celui-ci"
+        }
+      }
+    },
+    "error": {
+      "auth": "Fournissez un mot de passe ou un fichier de clé",
+      "duplicate_host": "Cet hôte a déjà été ajouté",
+      "host_in_use": "Cet hôte est déjà configuré"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add configurable SSH port support, multi-server setup, and an options flow for vserver ssh stats
- provide Home Assistant diagnostics export to meet silver quality expectations
- document sudo requirements, release workflow, and record the 1.2.7 changelog

## Testing
- python -m compileall custom_components/vserver_ssh_stats

------
https://chatgpt.com/codex/tasks/task_e_68c905e64c8c832794967a765a833e76