### PR TITLE
docs: update release notes for v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.2.8
+- Documentation and metadata updates for the v1.2.8 release.
+
 ## v1.2.7
 - Added configurable SSH port support to the onboarding flow and stored server definitions.
 - Enabled multi-server setup directly from the UI and provided an options flow to edit the list later on.

--- a/README.de.md
+++ b/README.de.md
@@ -112,8 +112,8 @@ cards:
 ---
 
 ## Release-Management
-- Aktuelle stabile Version: **v1.2.7** (siehe `manifest.json`).
-- Erstellen Sie für jede veröffentlichte Version ein Git-Tag (z. B. `git tag v1.2.7`) sowie ein zugehöriges GitHub-Release, damit HACS Updates sauber nachvollziehen kann.
+- Aktuelle stabile Version: **v1.2.8** (siehe `manifest.json`).
+- Erstellen Sie für jede veröffentlichte Version ein Git-Tag (z. B. `git tag v1.2.8`) sowie ein zugehöriges GitHub-Release, damit HACS Updates sauber nachvollziehen kann.
 - Nutzen Sie das vorhandene Skript `scripts/bump_version.py`, um die Versionsnummer der Integration vor einer neuen Veröffentlichung zu erhöhen.
 - Pflegen Sie wichtige Änderungen zusätzlich in der [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/README.es.md
+++ b/README.es.md
@@ -112,8 +112,8 @@ cards:
 ---
 
 ## Gestión de lanzamientos
-- Versión estable actual: **v1.2.7** (coincide con `manifest.json`).
-- Crea una etiqueta Git (por ejemplo, `git tag v1.2.7`) y una versión en GitHub para cada lanzamiento a fin de que HACS pueda seguir las actualizaciones correctamente.
+- Versión estable actual: **v1.2.8** (coincide con `manifest.json`).
+- Crea una etiqueta Git (por ejemplo, `git tag v1.2.8`) y una versión en GitHub para cada lanzamiento a fin de que HACS pueda seguir las actualizaciones correctamente.
 - Utiliza el script existente `scripts/bump_version.py` para incrementar la versión de la integración al preparar una nueva publicación.
 - Registra los cambios relevantes en [`CHANGELOG.md`](CHANGELOG.md) junto con cada versión.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -112,8 +112,8 @@ cards:
 ---
 
 ## Gestion des versions
-- Version stable actuelle : **v1.2.7** (conforme à `manifest.json`).
-- Créez une étiquette Git (par exemple `git tag v1.2.7`) et une publication GitHub pour chaque version afin que HACS puisse suivre correctement les mises à jour.
+- Version stable actuelle : **v1.2.8** (conforme à `manifest.json`).
+- Créez une étiquette Git (par exemple `git tag v1.2.8`) et une publication GitHub pour chaque version afin que HACS puisse suivre correctement les mises à jour.
 - Utilisez le script `scripts/bump_version.py` existant pour incrémenter la version de l'intégration lors de la préparation d'une nouvelle publication.
 - Consignez les changements importants dans [`CHANGELOG.md`](CHANGELOG.md) pour chaque version.
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ cards:
 ---
 
 ## Release Management
-- Current stable release: **v1.2.7** (matching `manifest.json`).
-- Create a Git tag (e.g. `git tag v1.2.7`) and a corresponding GitHub release for every published version so HACS can track updates reliably.
+- Current stable release: **v1.2.8** (matching `manifest.json`).
+- Create a Git tag (e.g. `git tag v1.2.8`) and a corresponding GitHub release for every published version so HACS can track updates reliably.
 - Use the existing `scripts/bump_version.py` helper to increment the integration version when preparing a new release.
 - Document notable changes in [`CHANGELOG.md`](CHANGELOG.md) alongside each release.
 


### PR DESCRIPTION
## Summary
- update release references in all READMEs to point to v1.2.8
- add a changelog entry documenting the v1.2.8 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9298d32a48327b585236383a41959