### PR TITLE
Add host availability binary sensor and shared coordinators

### DIFF
--- a/FEATURE_BACKLOG.md
+++ b/FEATURE_BACKLOG.md
@@ -4,80 +4,75 @@ This backlog captures practical enhancements that could be added to the integrat
 
 ## High Impact
 
-1. **Host availability binary sensor**
-   - Add `binary_sensor.<name>_online` with clear `on/off` state and `last_seen` attribute.
-   - Helps automations react faster than parsing many sensor `unavailable` states.
-
-2. **Connection quality metrics**
+1. **Connection quality metrics**
    - Expose SSH connect latency and command roundtrip time sensors.
    - Useful to detect network degradation before hard outages.
 
-3. **Filesystem coverage**
+2. **Filesystem coverage**
    - Track multiple mount points (for example `/`, `/var`, `/home`, `/data`) instead of only root.
    - Include per-mount used/available GiB plus utilization percent.
 
-4. **Power and energy metrics**
+3. **Power and energy metrics**
    - Add optional sensors for RAPL/energy counters where supported.
    - Enable energy dashboards and anomaly alerts for servers with changing power draw.
 
-5. **Process-level hotspot detection**
+4. **Process-level hotspot detection**
    - Optional top-N process sensor attributes (CPU and memory consumers).
    - Speeds up troubleshooting when system load spikes.
 
 ## Reliability and UX
 
-6. **Adaptive polling/backoff**
+5. **Adaptive polling/backoff**
    - Automatically increase polling interval after repeated connection errors.
    - Return to normal interval after successful reconnects.
 
-7. **Per-host command timeout configuration**
+6. **Per-host command timeout configuration**
    - Add options for SSH connect timeout and remote command timeout.
    - Prevent one slow host from stalling collector cycles.
 
-8. **Service call result entities/events**
+7. **Service call result entities/events**
    - Create dedicated event payload schema and optional last-run status sensors for package update/reboot commands.
    - Easier to build robust notifications in Home Assistant.
 
-9. **Entity categories and diagnostics metadata**
+8. **Entity categories and diagnostics metadata**
    - Mark config/informational entities with suitable Home Assistant categories.
    - Improves dashboard organization and reduces clutter in default views.
 
-10. **Richer diagnostics export**
+9. **Richer diagnostics export**
     - Include sanitized timing, command failures, and capability detection in diagnostics output.
     - Makes bug reports easier for maintainers to triage.
 
 ## Security and Governance
 
-11. **Safer command policy**
+10. **Safer command policy**
     - Add optional allowlist for `run_command` service.
     - Reduces accidental execution of unsafe commands.
 
-12. **Least-privilege setup helper**
+11. **Least-privilege setup helper**
     - Provide a guided sudoers template generator in docs/scripts.
     - Makes secure onboarding faster and less error-prone.
 
-13. **Credential health checks**
+12. **Credential health checks**
     - Warn when password auth is used or key permissions are weak.
     - Encourage secure defaults directly in config flow.
 
 ## Nice-to-Have
 
-14. **Template dashboard blueprint**
+13. **Template dashboard blueprint**
     - Ship reusable Lovelace dashboard templates for single and multi-host deployments.
 
-15. **Historical trend helper sensors**
+14. **Historical trend helper sensors**
     - Expose short-term rolling averages (for example 5-minute CPU/memory) to smooth noisy metrics.
 
-16. **Host grouping labels**
+15. **Host grouping labels**
     - Add host tags (prod/stage/lab) as attributes to simplify area-based dashboards and automations.
 
-17. **Update channels and release notification sensor**
+16. **Update channels and release notification sensor**
     - Optional sensor comparing installed integration version vs latest published release.
 
 ## Suggested Implementation Order
 
-1. Availability binary sensor + backoff.
-2. Connection quality metrics + timeout controls.
-3. Multi-mount filesystem metrics.
-4. Security controls around remote command execution.
-5. Process hotspot and energy metrics.
+1. Connection quality metrics + timeout controls.
+2. Multi-mount filesystem metrics.
+3. Security controls around remote command execution.
+4. Process hotspot and energy metrics.

--- a/custom_components/vserver_ssh_stats/__init__.py
+++ b/custom_components/vserver_ssh_stats/__init__.py
@@ -17,7 +17,7 @@ from .util import resolve_private_key_path
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "vserver_ssh_stats"
-PLATFORMS: list[str] = ["sensor", "button"]
+PLATFORMS: list[str] = ["sensor", "binary_sensor", "button"]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 SUPPORTED_TARGET_OS = {"auto", "debian", "raspbian", "windows"}

--- a/custom_components/vserver_ssh_stats/binary_sensor.py
+++ b/custom_components/vserver_ssh_stats/binary_sensor.py
@@ -1,0 +1,82 @@
+"""Binary sensor platform for VServer SSH Stats."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import DOMAIN
+from .coordinator import VServerCoordinator, async_get_or_create_coordinators
+
+
+class VServerOnlineBinarySensor(CoordinatorEntity[VServerCoordinator], BinarySensorEntity):
+    """Binary sensor representing host availability."""
+
+    def __init__(self, coordinator: VServerCoordinator, server_name: str) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        host = coordinator.server["host"]
+        self._attr_unique_id = f"{host}_online"
+        self._attr_name = f"{server_name} Online"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, host)},
+            name=server_name,
+        )
+        self._last_seen: str | None = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the host is reachable."""
+        return self.coordinator.last_update_success
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional availability context."""
+        return {"last_seen": self._last_seen}
+
+    @property
+    def available(self) -> bool:
+        """Always keep the entity available so automations can read an off state."""
+        return True
+
+    @property
+    def should_poll(self) -> bool:
+        """Coordinator handles polling."""
+        return False
+
+    @property
+    def force_update(self) -> bool:
+        """Do not force recorder updates for unchanged states."""
+        return False
+
+    @property
+    def icon(self) -> str:
+        """Return a dynamic icon for availability."""
+        return "mdi:lan-connect" if self.is_on else "mdi:lan-disconnect"
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.coordinator.last_update_success and self.coordinator.data:
+            self._last_seen = datetime.now(UTC).isoformat()
+        super()._handle_coordinator_update()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up VServer SSH Stats binary sensors based on a config entry."""
+    entities: list[VServerOnlineBinarySensor] = []
+    coordinators = await async_get_or_create_coordinators(hass, entry)
+    for coordinator in coordinators:
+        name = coordinator.server.get("name")
+        if not name:
+            continue
+        entities.append(VServerOnlineBinarySensor(coordinator, name))
+    async_add_entities(entities, update_before_add=True)

--- a/custom_components/vserver_ssh_stats/coordinator.py
+++ b/custom_components/vserver_ssh_stats/coordinator.py
@@ -1,0 +1,79 @@
+"""Coordinator helpers shared across platforms."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from . import DOMAIN
+from .ssh_collector import async_sample
+
+_LOGGER = logging.getLogger(__name__)
+COORDINATORS_KEY = "coordinators"
+COORDINATOR_LOCK_KEY = "coordinators_lock"
+
+
+class VServerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator that polls a server via SSH."""
+
+    def __init__(self, hass: HomeAssistant, server: dict[str, Any], interval: int) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=server["name"],
+            update_interval=timedelta(seconds=interval),
+        )
+        self.server = server
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from the server."""
+        try:
+            return await async_sample(
+                self.server["host"],
+                self.server["username"],
+                self.server.get("password"),
+                self.server.get("key"),
+                self.server.get("port", 22),
+                self.server.get("target_os", "auto"),
+            )
+        except socket.gaierror as err:
+            raise UpdateFailed(f"Unable to resolve host: {self.server['host']}") from err
+
+
+async def async_get_or_create_coordinators(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> list[VServerCoordinator]:
+    """Return coordinators for a config entry, creating them once."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry_data.get(COORDINATORS_KEY)
+    if coordinators is not None:
+        return coordinators
+
+    lock = entry_data.setdefault(COORDINATOR_LOCK_KEY, asyncio.Lock())
+    async with lock:
+        coordinators = entry_data.get(COORDINATORS_KEY)
+        if coordinators is not None:
+            return coordinators
+
+        interval = entry_data.get("interval", 30)
+        coordinators = []
+        for server in entry_data.get("servers", []):
+            if not server.get("name"):
+                continue
+            coordinators.append(VServerCoordinator(hass, server, interval))
+
+        if coordinators:
+            await asyncio.gather(
+                *(coordinator.async_config_entry_first_refresh() for coordinator in coordinators)
+            )
+
+        entry_data[COORDINATORS_KEY] = coordinators
+        return coordinators

--- a/custom_components/vserver_ssh_stats/sensor.py
+++ b/custom_components/vserver_ssh_stats/sensor.py
@@ -1,12 +1,8 @@
 """Sensor platform for VServer SSH Stats."""
 from __future__ import annotations
 
-import asyncio
-import logging
 import re
-import socket
 from dataclasses import dataclass, field
-from datetime import timedelta
 from typing import Any, Callable, Dict, Iterable
 
 from homeassistant.components.sensor import (
@@ -26,17 +22,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN
-from .ssh_collector import async_sample
-
-_LOGGER = logging.getLogger(__name__)
-
+from .coordinator import VServerCoordinator, async_get_or_create_coordinators
 
 def _sanitize(name: str) -> str:
     """Sanitize a container name for use in entity keys."""
@@ -206,34 +195,6 @@ SENSORS: tuple[VServerSensorDescription, ...] = (
 )
 
 
-class VServerCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
-    """Coordinator that polls a server via SSH."""
-
-    def __init__(self, hass: HomeAssistant, server: Dict[str, Any], interval: int) -> None:
-        """Initialize the coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=server["name"],
-            update_interval=timedelta(seconds=interval),
-        )
-        self.server = server
-
-    async def _async_update_data(self) -> Dict[str, Any]:
-        """Fetch data from the server."""
-        try:
-            return await async_sample(
-                self.server["host"],
-                self.server["username"],
-                self.server.get("password"),
-                self.server.get("key"),
-                self.server.get("port", 22),
-                self.server.get("target_os", "auto"),
-            )
-        except socket.gaierror as err:
-            raise UpdateFailed(f"Unable to resolve host: {self.server['host']}") from err
-
-
 class VServerSensor(CoordinatorEntity[VServerCoordinator], SensorEntity):
     """Representation of a VServer SSH Stats sensor."""
 
@@ -267,27 +228,18 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up VServer SSH Stats sensors based on a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    servers = data.get("servers", [])
-    interval = data.get("interval", 30)
     entities: list[VServerSensor] = []
-    coordinators: list[VServerCoordinator] = []
     registries: list[tuple[ServerContainerRegistry, ServerDiskRegistry, str]] = []
-    for srv in servers:
-        name = srv.get("name")
+    coordinators = await async_get_or_create_coordinators(hass, entry)
+    for coordinator in coordinators:
+        name = coordinator.server.get("name")
         if not name:
             continue
-        coordinator = VServerCoordinator(hass, srv, interval)
-        coordinators.append(coordinator)
         container_registry = ServerContainerRegistry(coordinator, name)
         disk_registry = ServerDiskRegistry(coordinator, name)
         registries.append((container_registry, disk_registry, name))
         for description in SENSORS:
             entities.append(VServerSensor(coordinator, name, description))
-    if coordinators:
-        await asyncio.gather(
-            *(coordinator.async_config_entry_first_refresh() for coordinator in coordinators)
-        )
     for container_registry, disk_registry, _name in registries:
         coordinator = container_registry.coordinator
         stats = coordinator.data if isinstance(coordinator.data, dict) else {}


### PR DESCRIPTION
### Motivation

- Provide a clear per-host availability entity with explicit `on/off` state and a `last_seen` timestamp so automations can react faster than parsing many `unavailable` sensor states. 
- Avoid duplicating SSH polling logic across platforms by centralizing coordinator creation and lifecycle so platforms share pollers and initial refreshes. 
- Mark the backlog item as implemented and renumber the remaining backlog entries.

### Description

- Add `custom_components/vserver_ssh_stats/binary_sensor.py` implementing `VServerOnlineBinarySensor` that reports availability via `is_on` (backed by the coordinator), exposes a `last_seen` attribute, stays `available` so off states are readable, and provides a dynamic icon. 
- Add `custom_components/vserver_ssh_stats/coordinator.py` with `VServerCoordinator` and `async_get_or_create_coordinators` to create and reuse coordinators per config entry and perform the initial `async_config_entry_first_refresh`. 
- Update `custom_components/vserver_ssh_stats/sensor.py` to consume the shared coordinators via `async_get_or_create_coordinators` instead of creating inline coordinators, register the `binary_sensor` platform in `custom_components/vserver_ssh_stats/__init__.py`, and remove the implemented item from `FEATURE_BACKLOG.md` with renumbering. 

### Testing

- Ran `python -m compileall custom_components/vserver_ssh_stats` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78378e4d483279177d8448793fbe9)