### PR TITLE
Fix options flow crash when opening integration settings

### DIFF
--- a/custom_components/vserver_ssh_stats/config_flow.py
+++ b/custom_components/vserver_ssh_stats/config_flow.py
@@ -248,7 +248,7 @@ class OptionsFlowHandler(OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialise the options flow."""
 
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self._interval: int = config_entry.data.get("interval", DEFAULT_INTERVAL)
         try:
             self._existing_servers: list[dict[str, Any]] = json.loads(
@@ -368,9 +368,9 @@ class OptionsFlowHandler(OptionsFlow):
             "interval": self._interval,
             "servers_json": json.dumps(servers),
         }
-        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        self.hass.config_entries.async_update_entry(self._config_entry, data=data)
         self.hass.async_create_task(
-            self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            self.hass.config_entries.async_reload(self._config_entry.entry_id)
         )
 
     async def _get_discovered_hosts(self) -> list[str]:
@@ -398,7 +398,7 @@ class OptionsFlowHandler(OptionsFlow):
         """Return True if *host* is already configured in another entry."""
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.entry_id == self.config_entry.entry_id:
+            if entry.entry_id == self._config_entry.entry_id:
                 continue
             try:
                 servers = json.loads(entry.data.get("servers_json", "[]"))


### PR DESCRIPTION
### Motivation
- Opening the integration settings raised `AttributeError: property 'config_entry' of 'OptionsFlowHandler' object has no setter`, causing a 500 error and preventing editing configured servers in newer Home Assistant versions. 
- The root cause was assigning to the base flow's read-only `config_entry` property inside `OptionsFlowHandler.__init__` instead of storing the provided entry on a private attribute.

### Description
- Replace assignment `self.config_entry = config_entry` with `self._config_entry = config_entry` in `OptionsFlowHandler.__init__` to avoid writing to a read-only property. 
- Update calls that previously referenced `self.config_entry` to use `self._config_entry` for `async_update_entry`, `async_reload`, and duplicate-host checks. 
- Keep behaviour identical otherwise by continuing to load and resolve existing servers and pending server handling.

### Testing
- Verified the modified file compiles successfully with `python -m compileall custom_components/vserver_ssh_stats/config_flow.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f586257f588327a20416301807bcf4)