### PR TITLE
Fix service status detection regexes for ssh/web/vnc

### DIFF
--- a/custom_components/vserver_ssh_stats/remote_script.py
+++ b/custom_components/vserver_ssh_stats/remote_script.py
@@ -210,19 +210,19 @@ read_service_status() {
     sock_cmd="netstat -tuln"
   fi
 
-  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':22\\s' >/dev/null; then
+  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':22[[:space:]]' >/dev/null; then
     ssh_enabled="yes"
   else
     ssh_enabled="no"
   fi
 
-  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':(80|443)\\s' >/dev/null; then
+  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':(80|443)[[:space:]]' >/dev/null; then
     web="yes"
   else
     web="no"
   fi
 
-  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':5900\\s' >/dev/null; then
+  if [ -n "$sock_cmd" ] && $sock_cmd 2>/dev/null | grep -E ':5900[[:space:]]' >/dev/null; then
     vnc="yes"
   elif command -v vncserver >/dev/null 2>&1 || command -v x11vnc >/dev/null 2>&1; then
     vnc="yes"


### PR DESCRIPTION
### Motivation
- Service sensors (`ssh_enabled`, `web`, `vnc`) were always reporting `no` due to incorrect grep ERE whitespace escapes in `read_service_status()` which caused false negatives when detecting listening ports.

### Description
- Replace the incorrect escaped `\s` sequences with the POSIX `[[:space:]]` character class in the grep `-E` patterns for ports `22`, `80|443`, and `5900` in `custom_components/vserver_ssh_stats/remote_script.py` so port listening checks reliably match whitespace after the port.

### Testing
- Ran `python -m py_compile custom_components/vserver_ssh_stats/remote_script.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f589c21b708327b289341a2a319118)